### PR TITLE
feat: azure: enumerate public IP addresses

### DIFF
--- a/pkg/providers/azure/publicips.go
+++ b/pkg/providers/azure/publicips.go
@@ -1,0 +1,60 @@
+package azure
+
+import (
+	"context"
+
+	"github.com/Azure/azure-sdk-for-go/profiles/latest/network/mgmt/network"
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/projectdiscovery/cloudlist/pkg/schema"
+)
+
+// publicIPProvider is a public ip provider for Azure API
+type publicIPProvider struct {
+	id             string
+	SubscriptionID string
+	Authorizer     autorest.Authorizer
+}
+
+// GetResource returns all the resources in the store for a provider.
+func (pip *publicIPProvider) GetResource(ctx context.Context) (*schema.Resources, error) {
+
+	list := schema.NewResources()
+
+	ips, err := pip.fetchPublicIPs(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, ip := range ips {
+		list.Append(&schema.Resource{
+			Provider:   providerName,
+			PublicIPv4: *ip.IPAddress,
+			ID:         pip.id,
+			Public:     true,
+		})
+	}
+	return list, nil
+}
+
+func (pip *publicIPProvider) fetchPublicIPs(ctx context.Context) ([]network.PublicIPAddress, error) {
+	var ips []network.PublicIPAddress
+
+	ipClient := network.NewPublicIPAddressesClient(pip.SubscriptionID)
+	ipClient.Authorizer = pip.Authorizer
+
+	ipsIt, err := ipClient.ListAllComplete(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	for ipsIt.NotDone() {
+		ip := ipsIt.Value()
+		ips = append(ips, ip)
+
+		if err = ipsIt.NextWithContext(ctx); err != nil {
+			return ips, err
+		}
+	}
+
+	return ips, err
+}


### PR DESCRIPTION
Adds support for enumerating public IP addresses in Azure.

Currently, cloudlist only supports VM enumeration. This PR expands the capability of cloudlist to also allow enumeration of public ip addresses via a different API.

This doesn't introduce any requirements for new permissions since `Microsoft.Network/publicIPAddresses/read` was already required for the vm enumeration to work.