### PR TITLE
gcp: Modify GCP provider to fallback to ADC if `gcp_service_account_key` is not set [#531]

### DIFF
--- a/pkg/providers/gcp/gcp.go
+++ b/pkg/providers/gcp/gcp.go
@@ -36,16 +36,19 @@ func (p *Provider) ID() string {
 
 // New creates a new provider client for gcp API
 func New(options schema.OptionBlock) (*Provider, error) {
-	JSONData, ok := options.GetMetadata(serviceAccountJSON)
-	if !ok {
-		return nil, errorutil.New("could not get API Key")
+	var saKeyBytes []byte
+	saKeyString, ok := options.GetMetadata(serviceAccountJSON)
+	if ok {
+		saKeyBytes = []byte(saKeyString)
 	}
+
 	id, _ := options.GetMetadata("id")
 
-	creds, err := register(context.Background(), []byte(JSONData))
+	creds, err := register(context.Background(), []byte(saKeyBytes))
 	if err != nil {
 		return nil, errorutil.NewWithErr(err).Msgf("could not register gcp service account")
 	}
+
 	dnsService, err := dns.NewService(context.Background(), creds)
 	if err != nil {
 		return nil, errorutil.NewWithErr(err).Msgf("could not create dns service with api key")


### PR DESCRIPTION
This change updates the authentication logic in the GCP provider to fallback and use [application default credentials](https://cloud.google.com/docs/authentication/provide-credentials-adc) when authenticating with GCP instead of requiring that `gcp_service_account_key` be set in the provider configuration. Using ADC by default is the default behavior for the Google Cloud SDK and most applications that call GCP APIs.

Using ADC also allows `cloudlist` to authenticate with GCP using temporary credentials when running on workloads in GCP instead of using static credentials (something Google recommends against).