### PR TITLE
Feature/discover azure subscriptions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 cmd/cloudlist/cloudlist
 .DS_Store
 dist
+.env
+provider-config.yaml

--- a/pkg/providers/azure/azure.go
+++ b/pkg/providers/azure/azure.go
@@ -1,135 +1,180 @@
 package azure
 
 import (
-	"context"
-	"fmt"
-	"strings"
+    "context"
+    "fmt"
+    "strings"
 
-	"github.com/Azure/go-autorest/autorest"
-	"github.com/Azure/go-autorest/autorest/azure/auth"
-	"github.com/projectdiscovery/cloudlist/pkg/schema"
-	"github.com/projectdiscovery/gologger"
+    "github.com/Azure/azure-sdk-for-go/profiles/latest/resources/mgmt/subscriptions"
+    "github.com/Azure/go-autorest/autorest"
+    "github.com/Azure/go-autorest/autorest/azure/auth"
+    "github.com/projectdiscovery/cloudlist/pkg/schema"
+    "github.com/projectdiscovery/gologger"
 )
 
 const (
-	id             = `id`
-	tenantID       = `tenant_id`
-	clientID       = `client_id`
-	clientSecret   = `client_secret`
-	subscriptionID = `subscription_id`
-	useCliAuth     = `use_cli_auth`
+    id             = `id`
+    tenantID       = `tenant_id`
+    clientID       = `client_id`
+    clientSecret   = `client_secret`
+    subscriptionID = `subscription_id` // optional
+    useCliAuth     = `use_cli_auth`
 
-	providerName = "azure"
+    providerName = "azure"
 )
 
 var Services = []string{"vm", "publicip"}
 
 // Provider is a data provider for Azure API
 type Provider struct {
-	id             string
-	SubscriptionID string
-	Authorizer     autorest.Authorizer
-	services       schema.ServiceMap
+    id              string
+    SubscriptionIDs []string
+    Authorizer      autorest.Authorizer
+    services        schema.ServiceMap
 }
 
 // New creates a new provider client for Azure API
 func New(options schema.OptionBlock) (*Provider, error) {
-	SubscriptionID, ok := options.GetMetadata(subscriptionID)
-	if !ok {
-		return nil, &schema.ErrNoSuchKey{Name: subscriptionID}
-	}
+    ID, _ := options.GetMetadata(id)
+    UseCliAuth, _ := options.GetMetadata(useCliAuth)
 
-	UseCliAuth, _ := options.GetMetadata(useCliAuth)
+    var authorizer autorest.Authorizer
+    var err error
 
-	ID, _ := options.GetMetadata(id)
+    if UseCliAuth == "true" {
+        authorizer, err = auth.NewAuthorizerFromCLI()
+        if err != nil {
+            gologger.Error().Msgf("Couldn't authorize using cli: %s\n", err)
+            return nil, err
+        }
+    } else {
+        ClientID, ok := options.GetMetadata(clientID)
+        if !ok {
+            return nil, &schema.ErrNoSuchKey{Name: clientID}
+        }
+        ClientSecret, ok := options.GetMetadata(clientSecret)
+        if !ok {
+            return nil, &schema.ErrNoSuchKey{Name: clientSecret}
+        }
+        TenantID, ok := options.GetMetadata(tenantID)
+        if !ok {
+            return nil, &schema.ErrNoSuchKey{Name: tenantID}
+        }
 
-	var authorizer autorest.Authorizer
-	var err error
+        config := auth.NewClientCredentialsConfig(ClientID, ClientSecret, TenantID)
+        authorizer, err = config.Authorizer()
+        if err != nil {
+            return nil, err
+        }
+    }
 
-	if UseCliAuth == "true" {
-		authorizer, err = auth.NewAuthorizerFromCLI()
-		if err != nil {
-			gologger.Error().Msgf("Couldn't authorize using cli: %s\n", err)
-			return nil, err
-		}
-	} else {
-		ClientID, ok := options.GetMetadata(clientID)
-		if !ok {
-			return nil, &schema.ErrNoSuchKey{Name: clientID}
-		}
-		ClientSecret, ok := options.GetMetadata(clientSecret)
-		if !ok {
-			return nil, &schema.ErrNoSuchKey{Name: clientSecret}
-		}
-		TenantID, ok := options.GetMetadata(tenantID)
-		if !ok {
-			return nil, &schema.ErrNoSuchKey{Name: tenantID}
-		}
+    // Parse services
+    supportedServicesMap := make(map[string]struct{})
+    for _, s := range Services {
+        supportedServicesMap[s] = struct{}{}
+    }
+    services := make(schema.ServiceMap)
+    if ss, ok := options.GetMetadata("services"); ok {
+        for _, s := range strings.Split(ss, ",") {
+            if _, ok := supportedServicesMap[s]; ok {
+                services[s] = struct{}{}
+            }
+        }
+    }
+    if len(services) == 0 {
+        for _, s := range Services {
+            services[s] = struct{}{}
+        }
+    }
 
-		config := auth.NewClientCredentialsConfig(ClientID, ClientSecret, TenantID)
-		authorizer, err = config.Authorizer()
-		if err != nil {
-			return nil, err
-		}
-	}
+    provider := &Provider{
+        Authorizer: authorizer,
+        id:         ID,
+        services:   services,
+    }
 
-	supportedServicesMap := make(map[string]struct{})
-	for _, s := range Services {
-		supportedServicesMap[s] = struct{}{}
-	}
-	services := make(schema.ServiceMap)
-	if ss, ok := options.GetMetadata("services"); ok {
-		for _, s := range strings.Split(ss, ",") {
-			if _, ok := supportedServicesMap[s]; ok {
-				services[s] = struct{}{}
-			}
-		}
-	}
-	if len(services) == 0 {
-		for _, s := range Services {
-			services[s] = struct{}{}
-		}
-	}
-	return &Provider{Authorizer: authorizer, SubscriptionID: SubscriptionID, id: ID, services: services}, nil
+    // Check if a specific subscription ID was provided
+    specifiedSubID, hasSpecificSub := options.GetMetadata(subscriptionID)
 
+    // If a specific subscription was provided, use only that one
+    if hasSpecificSub && specifiedSubID != "" {
+        provider.SubscriptionIDs = []string{specifiedSubID}
+        return provider, nil
+    }
+
+    // Otherwise, discover all available subscriptions
+    gologger.Info().Msgf("Listing subscriptions from provider: azure")
+
+    ctx := context.Background()
+    subsClient := subscriptions.NewClient()
+    subsClient.Authorizer = authorizer
+
+    var subIDs []string
+    for subsList, err := subsClient.List(ctx); subsList.NotDone(); err = subsList.NextWithContext(ctx) {
+        if err != nil {
+            return nil, fmt.Errorf("failed to list subscriptions: %v", err)
+        }
+
+        for _, sub := range subsList.Values() {
+            if sub.SubscriptionID != nil {
+                subIDs = append(subIDs, *sub.SubscriptionID)
+                gologger.Info().Msgf("Discovered subscription: %s", *sub.SubscriptionID)
+            }
+        }
+    }
+
+    if len(subIDs) == 0 {
+        return nil, fmt.Errorf("no subscriptions found for the provided credentials")
+    }
+
+    provider.SubscriptionIDs = subIDs
+    return provider, nil
 }
 
 // Name returns the name of the provider
 func (p *Provider) Name() string {
-	return providerName
+    return providerName
 }
 
 // ID returns the name of the provider id
 func (p *Provider) ID() string {
-	return p.id
+    return p.id
 }
 
 // Services returns the provider services
 func (p *Provider) Services() []string {
-	return p.services.Keys()
+    return p.services.Keys()
 }
 
 // Resources returns the provider for an resource deployment source.
 func (p *Provider) Resources(ctx context.Context) (*schema.Resources, error) {
-	resources := schema.NewResources()
+    resources := schema.NewResources()
 
-	if p.services.Has("vm") {
-		vmp := &vmProvider{Authorizer: p.Authorizer, SubscriptionID: p.SubscriptionID, id: p.id}
-		vmIPs, err := vmp.GetResource(ctx)
-		if err != nil {
-			return nil, fmt.Errorf("error listing VM public ips: %s", err)
-		}
-		resources.Merge(vmIPs)
-	}
+    // Process each subscription
+    for _, subscriptionID := range p.SubscriptionIDs {
+        gologger.Info().Msgf("Processing subscription: %s", subscriptionID)
 
-	if p.services.Has("publicip") {
+        if p.services.Has("vm") {
+            vmp := &vmProvider{Authorizer: p.Authorizer, SubscriptionID: subscriptionID, id: p.id}
+            vmIPs, err := vmp.GetResource(ctx)
+            if err != nil {
+                gologger.Warning().Msgf("Error listing VM public IPs for subscription %s: %s", subscriptionID, err)
+                continue
+            }
+            resources.Merge(vmIPs)
+        }
 
-		publicIPp := &publicIPProvider{Authorizer: p.Authorizer, SubscriptionID: p.SubscriptionID, id: p.id}
-		publicIPs, err := publicIPp.GetResource(ctx)
-		if err != nil {
-			return nil, fmt.Errorf("error listing public ips: %s", err)
-		}
-		resources.Merge(publicIPs)
-	}
-	return resources, nil
+        if p.services.Has("publicip") {
+            publicIPp := &publicIPProvider{Authorizer: p.Authorizer, SubscriptionID: subscriptionID, id: p.id}
+            publicIPs, err := publicIPp.GetResource(ctx)
+            if err != nil {
+                gologger.Warning().Msgf("Error listing public IPs for subscription %s: %s", subscriptionID, err)
+                continue
+            }
+            resources.Merge(publicIPs)
+        }
+    }
+
+    return resources, nil
 }
+


### PR DESCRIPTION
## Problem
Currently, users working with multi-subscription Azure environments must manually:
- Enumerate each subscription individually
- Run cloudlist multiple times with different subscription IDs
- Manage results from separate operations

## Solution
This PR enables cloudlist to automatically discover all Azure subscriptions the user/app has permissions for when no subscription_id is specified, allowing:
- Single-operation scanning across all accessible subscriptions
- Consistent resource discovery without manual subscription enumeration
- Improved workflow for organisations with Azure tenancies with multiple subscriptions

## Implementation Details
- Uses Azure SDK subscription client to retrieve accessible subscriptions
- Maintains backward compatibility with existing configuration options

## Testing
Tested against a single scenario
- Multiple subscriptions
- Reader permission
- CLI auth

### Sample output
```bash
./cloudlist -pc provider-config.yaml -p azure

  _______             _____     __ 
 / ___/ /__  __ _____/ / (_)__ / /_
/ /__/ / _ \/ // / _  / / (_-</ __/
\___/_/\___/\_,_/\_,_/_/_/___/\__/ 

                projectdiscovery.io

[INF] Current cloudlist version 1.2.1 (latest)
[INF] Listing subscriptions from provider: azure
[INF] Discovered subscription: adb71dea-10fb-42ff-9afd-redacted
[INF] Discovered subscription: cfb2dbf7-9908-41d9-a544-redacted
[INF] Listing assets from provider: azure services: vm,publicip id: 
[INF] Processing subscription: adb71dea-10fb-42ff-9afd-redacted
etc.
```