### PR TITLE
Improve-gcp-error-handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 cmd/cloudlist/cloudlist
 .DS_Store
 dist
+provider-config.yaml
+.env

--- a/pkg/providers/gcp/bucket.go
+++ b/pkg/providers/gcp/bucket.go
@@ -43,10 +43,13 @@ func (d *cloudStorageProvider) getBuckets() ([]*storage.Bucket, error) {
 	var buckets []*storage.Bucket
 	for _, project := range d.projects {
 		bucketsService := d.storage.Buckets.List(project)
-		_ = bucketsService.Pages(context.Background(), func(bal *storage.Buckets) error {
+		err := bucketsService.Pages(context.Background(), func(bal *storage.Buckets) error {
 			buckets = append(buckets, bal.Items...)
 			return nil
 		})
+		if err != nil {
+			return nil, FormatGoogleError(fmt.Errorf("could not list buckets for project %s: %w", project, err))
+		}
 	}
 	return buckets, nil
 }

--- a/pkg/providers/gcp/bucket.go
+++ b/pkg/providers/gcp/bucket.go
@@ -24,7 +24,7 @@ func (d *cloudStorageProvider) GetResource(ctx context.Context) (*schema.Resourc
 
 	buckets, err := d.getBuckets()
 	if err != nil {
-		return nil, fmt.Errorf("could not get buckets: %s", err)
+		return nil, fmt.Errorf("could not get buckets: %s", ExtractGoogleErrorReason(err))
 	}
 	for _, bucket := range buckets {
 		resource := &schema.Resource{
@@ -48,7 +48,7 @@ func (d *cloudStorageProvider) getBuckets() ([]*storage.Bucket, error) {
 			return nil
 		})
 		if err != nil {
-			return nil, FormatGoogleError(fmt.Errorf("could not list buckets for project %s: %w", project, err))
+			return nil, fmt.Errorf("could not list buckets for project %s: %s", project, ExtractGoogleErrorReason(err))
 		}
 	}
 	return buckets, nil

--- a/pkg/providers/gcp/cloud-run.go
+++ b/pkg/providers/gcp/cloud-run.go
@@ -26,7 +26,7 @@ func (d *cloudRunProvider) GetResource(ctx context.Context) (*schema.Resources, 
 	if err != nil {
 		return nil, fmt.Errorf("could not get services: %s", err)
 	}
-	
+
 	for _, service := range services {
 		serviceUrl, _ := url.Parse(service.Status.Url)
 		resource := &schema.Resource{
@@ -47,14 +47,14 @@ func (d *cloudRunProvider) getServices() ([]*run.Service, error) {
 		locationsService := d.run.Projects.Locations.List(fmt.Sprintf("projects/%s", project))
 		locationsResponse, err := locationsService.Do()
 		if err != nil {
-			continue
+			return nil, FormatGoogleError(fmt.Errorf("could not list locations for project %s: %w", project, err))
 		}
 
 		for _, location := range locationsResponse.Locations {
 			servicesService := d.run.Projects.Locations.Services.List(location.Name)
 			servicesResponse, err := servicesService.Do()
 			if err != nil {
-				continue
+				return nil, FormatGoogleError(fmt.Errorf("could not list services for location %s in project %s: %w", location.Name, project, err))
 			}
 			services = append(services, servicesResponse.Items...)
 		}

--- a/pkg/providers/gcp/errors.go
+++ b/pkg/providers/gcp/errors.go
@@ -1,12 +1,25 @@
 package gcp
 
 import (
+	"encoding/json"
 	"fmt"
+	"log"
+	"os"
 	"regexp"
 	"strings"
 )
 
-// ExtractGoogleErrorReason extracts a concise reason from Google API errors
+// googleRpcDetail is a minimal struct to map the objects inside the "Details" array.
+// We only parse the fields we specifically need, such as "@type" and "reason."
+type googleRpcDetail struct {
+	Type   string `json:"@type"`
+	Reason string `json:"reason"`
+}
+
+// ExtractGoogleErrorReason attempts to yield a concise error message
+// by parsing Google API errors. We look for "Error 403" plus a "Details:"
+// JSON array. We have also extended it to handle other HTTP codes or
+// text-based checks such as "access denied."
 func ExtractGoogleErrorReason(err error) string {
 	if err == nil {
 		return ""
@@ -14,30 +27,125 @@ func ExtractGoogleErrorReason(err error) string {
 
 	errMsg := err.Error()
 
-	// Check for the standard Google API error pattern
-	if strings.Contains(errMsg, "Error ") && strings.Contains(errMsg, "Details:") {
-		// Extract the status message
-		statusMatch := regexp.MustCompile(`Error \d+: (.+?)(\.?\s+Details:)`).FindStringSubmatch(errMsg)
-		if len(statusMatch) > 1 {
-			status := statusMatch[1]
-
-			// Look for the "reason" field in the Details JSON
-			reasonMatch := regexp.MustCompile(`"reason"\s*:\s*"([^"]+)"`).FindStringSubmatch(errMsg)
-			if len(reasonMatch) > 1 {
-				reason := reasonMatch[1]
-				return fmt.Sprintf("%s (%s)", status, reason)
-			}
-			return status
-		}
+	// Added: if it explicitly says "Access Denied" or "access denied" but no "Error 403":
+	if strings.Contains(strings.ToLower(errMsg), "access denied") {
+		return "Access denied (general). Possibly missing permissions or API not enabled."
 	}
 
-	// If we couldn't parse it, return the original error message
+	// Added: parse other codes, e.g. Error 401 or Error 404
+	// You could add more branches for other codes.
+	if strings.Contains(errMsg, "Error 401") {
+		return "Unauthorised request (401). Check your credentials."
+	}
+	if strings.Contains(errMsg, "Error 404") {
+		return "Resource not found (404)."
+	}
+
+	// Original logic for 403 + googleapi
+	if strings.Contains(errMsg, "Error 403") && strings.Contains(errMsg, "googleapi") {
+		// Extract the main portion of the message (e.g. "Permission denied on resource project rosterfy-sbx.")
+		mainMsg := extractMain403Message(errMsg)
+
+		// Look for the JSON array after "Details:"
+		jsonArray := extractDetailsArray(errMsg)
+		if jsonArray == "" {
+			// If we cannot find the details array, just return the main message
+			return fmt.Sprintf("Access denied: %s", mainMsg)
+		}
+
+		// Attempt to parse the JSON array to find any "reason" fields
+		reason := parseErrorReason(jsonArray)
+		if reason != "" {
+			// If we found a reason, add it
+			return fmt.Sprintf("Access denied: %s (Reason: %s)", mainMsg, reason)
+		}
+
+		// If no reason found, return the main error text
+		return fmt.Sprintf("Access denied: %s", mainMsg)
+	}
+
+	// If none of the above matches, do a fallback
+	return fallbackErrorMessage(errMsg)
+}
+
+// FormatGoogleError now wraps the error using ExtractGoogleErrorReason
+// so that any reason or code info is incorporated in the returned error string.
+// We also log the final message to a file for review.
+func FormatGoogleError(err error) error {
+	if err == nil {
+		return nil
+	}
+	finalMsg := ExtractGoogleErrorReason(err)
+
+	// Log the final string to a file before returning.
+	logErrorToFile(finalMsg)
+
+	return fmt.Errorf("%s", finalMsg)
+}
+
+// fallbackErrorMessage returns a shortened version if no known parsing rules match.
+// We can increase the limit from 150 to, say, 300 for a bit more detail.
+func fallbackErrorMessage(errMsg string) string {
+	if len(errMsg) > 300 {
+		return errMsg[:297] + "..."
+	}
 	return errMsg
 }
 
-// FormatGoogleError is a simple pass-through function to keep compatibility
-// with existing code using it
-func FormatGoogleError(err error) error {
-	// Simply return the error as-is
-	return err
+// extractMain403Message pulls out the text following "Error 403: ", up to a comma or newline.
+func extractMain403Message(errMsg string) string {
+	// Example:
+	//   "googleapi: Error 403: Permission denied on resource project rosterfy-sbx., forbidden"
+	r := regexp.MustCompile(`(?s)Error 403:\s+([^,\n]+)`)
+	matches := r.FindStringSubmatch(errMsg)
+	if len(matches) > 1 {
+		return strings.TrimSpace(matches[1])
+	}
+	return "Permission denied"
+}
+
+// extractDetailsArray finds the JSON segment immediately following "Details:", up to the next ']'.
+func extractDetailsArray(errMsg string) string {
+	// Expecting something like:
+	//   Details:
+	//   [
+	//     { "@type": "type.googleapis.com/google.rpc.ErrorInfo", "reason": "CONSUMER_INVALID" }
+	//   ],
+	r := regexp.MustCompile(`(?s)Details:\s*\[(.*?)\]`)
+	matches := r.FindStringSubmatch(errMsg)
+	if len(matches) > 1 {
+		return fmt.Sprintf("[%s]", matches[1])
+	}
+	return ""
+}
+
+// parseErrorReason unpacks our mini struct and grabs the first non-empty "reason" it finds.
+func parseErrorReason(jsonArray string) string {
+	var detailItems []googleRpcDetail
+	if err := json.Unmarshal([]byte(jsonArray), &detailItems); err != nil {
+		return ""
+	}
+	for _, item := range detailItems {
+		if item.Reason != "" {
+			return item.Reason
+		}
+	}
+	return ""
+}
+
+// logErrorToFile opens a file (creating it if needed) and appends the provided message.
+// This is a simple demonstration; in a production setting, you may want to:
+//   - keep this file open instead of re-opening for each log
+//   - implement a concurrency-safe approach (like a sync.Mutex or a logging library)
+func logErrorToFile(msg string) {
+	f, err := os.OpenFile("gcp_error_logs.txt", os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
+	if err != nil {
+		// If we cannot open the log file, just print to console as fallback
+		log.Printf("Could not open error log file: %v", err)
+		return
+	}
+	defer f.Close()
+
+	logger := log.New(f, "", log.LstdFlags)
+	logger.Println(msg)
 }

--- a/pkg/providers/gcp/errors.go
+++ b/pkg/providers/gcp/errors.go
@@ -1,0 +1,43 @@
+package gcp
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// ExtractGoogleErrorReason extracts a concise reason from Google API errors
+func ExtractGoogleErrorReason(err error) string {
+	if err == nil {
+		return ""
+	}
+
+	errMsg := err.Error()
+
+	// Check for the standard Google API error pattern
+	if strings.Contains(errMsg, "Error ") && strings.Contains(errMsg, "Details:") {
+		// Extract the status message
+		statusMatch := regexp.MustCompile(`Error \d+: (.+?)(\.?\s+Details:)`).FindStringSubmatch(errMsg)
+		if len(statusMatch) > 1 {
+			status := statusMatch[1]
+
+			// Look for the "reason" field in the Details JSON
+			reasonMatch := regexp.MustCompile(`"reason"\s*:\s*"([^"]+)"`).FindStringSubmatch(errMsg)
+			if len(reasonMatch) > 1 {
+				reason := reasonMatch[1]
+				return fmt.Sprintf("%s (%s)", status, reason)
+			}
+			return status
+		}
+	}
+
+	// If we couldn't parse it, return the original error message
+	return errMsg
+}
+
+// FormatGoogleError is a simple pass-through function to keep compatibility
+// with existing code using it
+func FormatGoogleError(err error) error {
+	// Simply return the error as-is
+	return err
+}

--- a/pkg/providers/gcp/errors_test.go
+++ b/pkg/providers/gcp/errors_test.go
@@ -1,0 +1,179 @@
+package gcp
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestExtractGoogleErrorReason(t *testing.T) {
+	// This string simulates a GCP 403 error that includes an embedded JSON array after "Details:"
+	mockErrString := `googleapi: Error 403: Permission denied on resource project test-project, forbidden
+Details:
+[
+  {
+    "@type": "type.googleapis.com/google.rpc.ErrorInfo",
+    "reason": "CONSUMER_INVALID"
+  }
+]`
+
+	result := ExtractGoogleErrorReason(errors.New(mockErrString))
+	expected := "Access denied: Permission denied on resource project test-project (Reason: CONSUMER_INVALID)"
+
+	if result != expected {
+		t.Errorf("expected:\n  %q\ngot:\n  %q", expected, result)
+	}
+}
+
+func TestFormatGoogleError(t *testing.T) {
+	// Same mock error as above. Now check FormatGoogleError directly.
+	mockErrString := `googleapi: Error 403: Permission denied on resource project test-project, forbidden
+Details:
+[
+  {
+    "@type": "type.googleapis.com/google.rpc.ErrorInfo",
+    "reason": "CONSUMER_INVALID"
+  }
+]`
+
+	err := FormatGoogleError(errors.New(mockErrString))
+	result := err.Error()
+	expected := "Access denied: Permission denied on resource project test-project (Reason: CONSUMER_INVALID)"
+
+	if result != expected {
+		t.Errorf("expected:\n  %q\ngot:\n  %q", expected, result)
+	}
+}
+
+func TestExtractGoogleErrorReasonWithFallback(t *testing.T) {
+	// This string simulates a GCP 403 error that includes an embedded JSON array after "Details:"
+	mockErrString := `googleapi: Error 403: Permission denied on resource project test-project, forbidden
+Details:
+[
+  {
+    "@type": "type.googleapis.com/google.rpc.ErrorInfo",
+    "reason": "CONSUMER_INVALID"
+  }
+]`
+
+	result := ExtractGoogleErrorReason(errors.New(mockErrString))
+	expected := "Access denied: Permission denied on resource project test-project (Reason: CONSUMER_INVALID)"
+
+	if result != expected {
+		t.Errorf("expected:\n  %q\ngot:\n  %q", expected, result)
+	}
+
+	// If an error line says "Error 401" or "Error 404" etc.:
+	if strings.Contains(mockErrString, "Error 401") {
+		// Return something like "Access unauthorised…"
+		t.Errorf("Access unauthorised…")
+	} else if strings.Contains(mockErrString, "Error 404") {
+		// Return "Resource not found…"
+		t.Errorf("Resource not found…")
+	} else if strings.Contains(mockErrString, "Error 405") {
+		// Return "Method not allowed…"
+		t.Errorf("Method not allowed…")
+	} else if strings.Contains(mockErrString, "Error 406") {
+		// Return "Not acceptable…"
+		t.Errorf("Not acceptable…")
+	} else if strings.Contains(mockErrString, "Error 407") {
+		// Return "Proxy authentication required…"
+		t.Errorf("Proxy authentication required…")
+	} else if strings.Contains(mockErrString, "Error 408") {
+		// Return "Request timeout…"
+		t.Errorf("Request timeout…")
+	} else if strings.Contains(mockErrString, "Error 409") {
+		// Return "Conflict…"
+		t.Errorf("Conflict…")
+	} else if strings.Contains(mockErrString, "Error 410") {
+		// Return "Gone…"
+		t.Errorf("Gone…")
+	} else if strings.Contains(mockErrString, "Error 411") {
+		// Return "Length required…"
+		t.Errorf("Length required…")
+	} else if strings.Contains(mockErrString, "Error 412") {
+		// Return "Precondition failed…"
+		t.Errorf("Precondition failed…")
+	} else if strings.Contains(mockErrString, "Error 413") {
+		// Return "Request entity too large…"
+		t.Errorf("Request entity too large…")
+	} else if strings.Contains(mockErrString, "Error 414") {
+		// Return "Request-URI too long…"
+		t.Errorf("Request-URI too long…")
+	} else if strings.Contains(mockErrString, "Error 415") {
+		// Return "Unsupported media type…"
+		t.Errorf("Unsupported media type…")
+	} else if strings.Contains(mockErrString, "Error 416") {
+		// Return "Requested range not satisfiable…"
+		t.Errorf("Requested range not satisfiable…")
+	} else if strings.Contains(mockErrString, "Error 417") {
+		// Return "Expectation failed…"
+		t.Errorf("Expectation failed…")
+	} else if strings.Contains(mockErrString, "Error 418") {
+		// Return "I'm a teapot…"
+		t.Errorf("I'm a teapot…")
+	} else if strings.Contains(mockErrString, "Error 421") {
+		// Return "Misdirected request…"
+		t.Errorf("Misdirected request…")
+	} else if strings.Contains(mockErrString, "Error 422") {
+		// Return "Unprocessable entity…"
+		t.Errorf("Unprocessable entity…")
+	} else if strings.Contains(mockErrString, "Error 423") {
+		// Return "Locked…"
+		t.Errorf("Locked…")
+	} else if strings.Contains(mockErrString, "Error 424") {
+		// Return "Failed dependency…"
+		t.Errorf("Failed dependency…")
+	} else if strings.Contains(mockErrString, "Error 425") {
+		// Return "Too early…"
+		t.Errorf("Too early…")
+	} else if strings.Contains(mockErrString, "Error 426") {
+		// Return "Upgrade required…"
+		t.Errorf("Upgrade required…")
+	} else if strings.Contains(mockErrString, "Error 428") {
+		// Return "Precondition required…"
+		t.Errorf("Precondition required…")
+	} else if strings.Contains(mockErrString, "Error 429") {
+		// Return "Too many requests…"
+		t.Errorf("Too many requests…")
+	} else if strings.Contains(mockErrString, "Error 431") {
+		// Return "Request header fields too large…"
+		t.Errorf("Request header fields too large…")
+	} else if strings.Contains(mockErrString, "Error 451") {
+		// Return "Unavailable for legal reasons…"
+		t.Errorf("Unavailable for legal reasons…")
+	} else if strings.Contains(mockErrString, "Error 500") {
+		// Return "Internal server error…"
+		t.Errorf("Internal server error…")
+	} else if strings.Contains(mockErrString, "Error 501") {
+		// Return "Not implemented…"
+		t.Errorf("Not implemented…")
+	} else if strings.Contains(mockErrString, "Error 502") {
+		// Return "Bad gateway…"
+		t.Errorf("Bad gateway…")
+	} else if strings.Contains(mockErrString, "Error 503") {
+		// Return "Service unavailable…"
+		t.Errorf("Service unavailable…")
+	} else if strings.Contains(mockErrString, "Error 504") {
+		// Return "Gateway timeout…"
+		t.Errorf("Gateway timeout…")
+	} else if strings.Contains(mockErrString, "Error 505") {
+		// Return "HTTP version not supported…"
+		t.Errorf("HTTP version not supported…")
+	} else if strings.Contains(mockErrString, "Error 506") {
+		// Return "Variant also negotiates…"
+		t.Errorf("Variant also negotiates…")
+	} else if strings.Contains(mockErrString, "Error 507") {
+		// Return "Insufficient storage…"
+		t.Errorf("Insufficient storage…")
+	} else if strings.Contains(mockErrString, "Error 508") {
+		// Return "Loop detected…"
+		t.Errorf("Loop detected…")
+	} else if strings.Contains(mockErrString, "Error 510") {
+		// Return "Not extended…"
+		t.Errorf("Not extended…")
+	} else if strings.Contains(mockErrString, "Error 511") {
+		// Return "Network authentication required…"
+		t.Errorf("Network authentication required…")
+	}
+}

--- a/pkg/providers/gcp/function.go
+++ b/pkg/providers/gcp/function.go
@@ -44,10 +44,13 @@ func (d *cloudFunctionsProvider) getFunctions() ([]*cloudfunctions.CloudFunction
 	var functions []*cloudfunctions.CloudFunction
 	for _, project := range d.projects {
 		functionsService := d.functions.Projects.Locations.Functions.List(fmt.Sprintf("projects/%s/locations/-", project))
-		_ = functionsService.Pages(context.Background(), func(fal *cloudfunctions.ListFunctionsResponse) error {
+		err := functionsService.Pages(context.Background(), func(fal *cloudfunctions.ListFunctionsResponse) error {
 			functions = append(functions, fal.Functions...)
 			return nil
 		})
+		if err != nil {
+			return nil, FormatGoogleError(fmt.Errorf("could not list functions for project %s: %w", project, err))
+		}
 	}
 	return functions, nil
 }

--- a/pkg/providers/gcp/function.go
+++ b/pkg/providers/gcp/function.go
@@ -24,7 +24,7 @@ func (d *cloudFunctionsProvider) GetResource(ctx context.Context) (*schema.Resou
 	list := schema.NewResources()
 	functions, err := d.getFunctions()
 	if err != nil {
-		return nil, fmt.Errorf("could not get functions: %s", err)
+		return nil, fmt.Errorf("could not get functions: %s", ExtractGoogleErrorReason(err))
 	}
 	for _, function := range functions {
 		funcUrl, _ := url.Parse(function.HttpsTrigger.Url)
@@ -49,7 +49,7 @@ func (d *cloudFunctionsProvider) getFunctions() ([]*cloudfunctions.CloudFunction
 			return nil
 		})
 		if err != nil {
-			return nil, FormatGoogleError(fmt.Errorf("could not list functions for project %s: %w", project, err))
+			return nil, fmt.Errorf("could not list functions for project %s: %s", project, ExtractGoogleErrorReason(err))
 		}
 	}
 	return functions, nil

--- a/pkg/providers/gcp/vms.go
+++ b/pkg/providers/gcp/vms.go
@@ -2,7 +2,7 @@ package gcp
 
 import (
 	"context"
-	"log"
+	"fmt"
 
 	"github.com/projectdiscovery/cloudlist/pkg/schema"
 	"google.golang.org/api/compute/v1"
@@ -51,8 +51,7 @@ func (d *cloudVMProvider) GetResource(ctx context.Context) (*schema.Resources, e
 			return nil
 		})
 		if err != nil {
-			log.Printf("Could not get all instances for project %s: %s\n", project, err)
-			continue
+			return nil, FormatGoogleError(fmt.Errorf("could not get all instances for project %s: %w", project, err))
 		}
 	}
 	return list, nil

--- a/pkg/providers/gcp/vms.go
+++ b/pkg/providers/gcp/vms.go
@@ -51,7 +51,7 @@ func (d *cloudVMProvider) GetResource(ctx context.Context) (*schema.Resources, e
 			return nil
 		})
 		if err != nil {
-			return nil, FormatGoogleError(fmt.Errorf("could not get all instances for project %s: %w", project, err))
+			return nil, fmt.Errorf("could not get all instances for project %s: %s", project, ExtractGoogleErrorReason(err))
 		}
 	}
 	return list, nil


### PR DESCRIPTION
Error handling for GCP provider was verbose, a GCP instance with a lot of project-ids may generate a lot of errors due to 403 status codes returned due to permissions issues or an API not being enabled (which is expected in many scenarios).