### PR TITLE
DNSSimple provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ cmd/cloudlist/cloudlist
 dist
 .env
 provider-config.yaml
+cloudlist
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 cmd/cloudlist/cloudlist
 .DS_Store
 dist
+.env
+provider-config.yaml

--- a/PROVIDERS.md
+++ b/PROVIDERS.md
@@ -406,3 +406,22 @@ References -
 - https://docs.aws.amazon.com/eks/latest/userguide/create-kubeconfig.html
 - https://learn.microsoft.com/en-us/azure/aks/control-kubeconfig-access#get-and-verify-the-configuration-information
 - https://cloud.google.com/kubernetes-engine/docs/how-to/cluster-access-for-kubectl#store_info
+
+### DNSSimple
+
+DNSSimple can be integrated by using the following configuration block.
+
+```yaml
+- # provider is the name of the provider
+  provider: dnssimple
+  # id is the name defined by user for filtering (optional)
+  id: main
+  # dnssimple_api_token is the API token for DNSSimple
+  dnssimple_api_token: $DNSSIMPLE_API_TOKEN
+```
+
+The `dnssimple_api_token` can be generated from the DNSSimple account settings under "API Access". You will need to create an API v2 token with appropriate permissions to access your domains and DNS records.
+
+References - 
+1. https://developer.dnsimple.com/v2/
+2. https://support.dnsimple.com/articles/api-access-token/

--- a/go.mod
+++ b/go.mod
@@ -196,6 +196,7 @@ require (
 	github.com/charmbracelet/lipgloss v0.13.0 // indirect
 	github.com/charmbracelet/x/ansi v0.3.2 // indirect
 	github.com/cloudflare/circl v1.3.7 // indirect
+	github.com/dnsimple/dnsimple-go v1.7.0 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/gaissmai/bart v0.17.10 // indirect
 	github.com/gofrs/flock v0.8.1 // indirect
@@ -204,6 +205,7 @@ require (
 	github.com/projectdiscovery/hmap v0.0.82 // indirect
 	github.com/projectdiscovery/retryabledns v1.0.94 // indirect
 	github.com/refraction-networking/utls v1.6.7 // indirect
+	github.com/shopspring/decimal v1.3.1 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/syndtr/goleveldb v1.0.0 // indirect
 	github.com/tidwall/btree v1.4.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -133,6 +133,8 @@ github.com/dlclark/regexp2 v1.11.4/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cn
 github.com/dnaeon/go-vcr v1.0.1/go.mod h1:aBB1+wY4s93YsC3HHjMBMrwTj2R9FHDzUr9KyGc8n1E=
 github.com/dnaeon/go-vcr v1.2.0 h1:zHCHvJYTMh1N7xnV7zf1m1GPBF9Ad0Jk/whtQ1663qI=
 github.com/dnaeon/go-vcr v1.2.0/go.mod h1:R4UdLID7HZT3taECzJs4YgbbH6PIGXB6W/sc5OLb6RQ=
+github.com/dnsimple/dnsimple-go v1.7.0 h1:JKu9xJtZ3SqOC+BuYgAWeab7+EEx0sz422vu8j611ZY=
+github.com/dnsimple/dnsimple-go v1.7.0/go.mod h1:EKpuihlWizqYafSnQHGCd/gyvy3HkEQJ7ODB4KdV8T8=
 github.com/docker/go-units v0.3.3/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4=
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
@@ -526,6 +528,8 @@ github.com/shoenig/go-m1cpu v0.1.6 h1:nxdKQNcEB6vzgA2E2bvzKIYRuNj7XNJ4S/aRSwKzFt
 github.com/shoenig/go-m1cpu v0.1.6/go.mod h1:1JJMcUBvfNwpq05QDQVAnx3gUHr9IYF7GNg9SUEw2VQ=
 github.com/shoenig/test v0.6.4 h1:kVTaSd7WLz5WZ2IaoM0RSzRsUD+m8wRR+5qvntpn4LU=
 github.com/shoenig/test v0.6.4/go.mod h1:byHiCGXqrVaflBLAMq/srcZIHynQPQgeyvkvXnjqq0k=
+github.com/shopspring/decimal v1.3.1 h1:2Usl1nmF/WZucqkFZhnfFYxxxu8LG21F6nPQBE5gKV8=
+github.com/shopspring/decimal v1.3.1/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.3.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=

--- a/pkg/inventory/inventory.go
+++ b/pkg/inventory/inventory.go
@@ -11,6 +11,7 @@ import (
 	"github.com/projectdiscovery/cloudlist/pkg/providers/consul"
 	"github.com/projectdiscovery/cloudlist/pkg/providers/custom"
 	"github.com/projectdiscovery/cloudlist/pkg/providers/digitalocean"
+	"github.com/projectdiscovery/cloudlist/pkg/providers/dnssimple"
 	"github.com/projectdiscovery/cloudlist/pkg/providers/fastly"
 	"github.com/projectdiscovery/cloudlist/pkg/providers/gcp"
 	"github.com/projectdiscovery/cloudlist/pkg/providers/heroku"
@@ -128,6 +129,8 @@ func nameToProvider(value string, block schema.OptionBlock) (schema.Provider, er
 		return k8s.New(block)
 	case "custom":
 		return custom.New(block)
+	case "dnssimple":
+		return dnssimple.New(block)
 	default:
 		return nil, fmt.Errorf("invalid provider name found: %s", value)
 	}

--- a/pkg/providers/dnssimple/dns.go
+++ b/pkg/providers/dnssimple/dns.go
@@ -23,16 +23,17 @@ func (d *dnsProvider) name() string {
 func (d *dnsProvider) GetResource(ctx context.Context) (*schema.Resources, error) {
 	list := schema.NewResources()
 
-	// List all domains
-	listOptions := &dnsimple.ListOptions{}
-	domains, err := d.client.Domains.ListDomains(ctx, d.account, listOptions)
+	// List all domains - using DomainListOptions instead of ListOptions
+	domainOptions := &dnsimple.DomainListOptions{}
+	domains, err := d.client.Domains.ListDomains(ctx, d.account, domainOptions)
 	if err != nil {
 		return nil, err
 	}
 
 	// For each domain, get its zone records
+	recordOptions := &dnsimple.ZoneRecordListOptions{}
 	for _, domain := range domains.Data {
-		zoneRecords, err := d.client.Zones.ListRecords(ctx, d.account, domain.Name, nil)
+		zoneRecords, err := d.client.Zones.ListRecords(ctx, d.account, domain.Name, recordOptions)
 		if err != nil {
 			log.Printf("Could not get records for domain %s: %s\n", domain.Name, err)
 			continue

--- a/pkg/providers/dnssimple/dns.go
+++ b/pkg/providers/dnssimple/dns.go
@@ -1,0 +1,75 @@
+package dnssimple
+
+import (
+	"context"
+	"log"
+
+	"github.com/dnsimple/dnsimple-go/dnsimple"
+	"github.com/projectdiscovery/cloudlist/pkg/schema"
+)
+
+// dnsProvider handles DNS records for DNSSimple
+type dnsProvider struct {
+	id      string
+	client  *dnsimple.Client
+	account string
+}
+
+func (d *dnsProvider) name() string {
+	return "dns"
+}
+
+// GetResource returns all DNS resources from DNSSimple
+func (d *dnsProvider) GetResource(ctx context.Context) (*schema.Resources, error) {
+	list := schema.NewResources()
+
+	// List all domains
+	listOptions := &dnsimple.ListOptions{}
+	domains, err := d.client.Domains.ListDomains(ctx, d.account, listOptions)
+	if err != nil {
+		return nil, err
+	}
+
+	// For each domain, get its zone records
+	for _, domain := range domains.Data {
+		zoneRecords, err := d.client.Zones.ListRecords(ctx, d.account, domain.Name, nil)
+		if err != nil {
+			log.Printf("Could not get records for domain %s: %s\n", domain.Name, err)
+			continue
+		}
+
+		for _, record := range zoneRecords.Data {
+			// Skip irrelevant record types
+			if record.Type != "A" && record.Type != "CNAME" && record.Type != "AAAA" {
+				continue
+			}
+
+			// Format DNS name properly
+			dnsName := record.Name
+			if dnsName == "" {
+				dnsName = domain.Name
+			} else {
+				dnsName = dnsName + "." + domain.Name
+			}
+
+			resource := &schema.Resource{
+				DNSName:  dnsName,
+				Public:   true,
+				ID:       d.id,
+				Provider: providerName,
+				Service:  d.name(),
+			}
+
+			// Set IP addresses based on record type
+			if record.Type == "A" {
+				resource.PublicIPv4 = record.Content
+			} else if record.Type == "AAAA" {
+				resource.PublicIPv6 = record.Content
+			}
+
+			list.Append(resource)
+		}
+	}
+
+	return list, nil
+}

--- a/pkg/providers/dnssimple/dnssimple.go
+++ b/pkg/providers/dnssimple/dnssimple.go
@@ -83,11 +83,12 @@ func New(options schema.OptionBlock) (*Provider, error) {
 		return nil, errorutil.NewWithErr(err).Msgf("failed to authenticate with DNSSimple")
 	}
 
-	if whoamiResponse.Data.Account != nil {
-		provider.account = fmt.Sprintf("%d", whoamiResponse.Data.Account.ID)
-	} else {
+	if whoamiResponse.Data.Account == nil {
 		return nil, errorutil.New("no account information found in DNSSimple response")
+
 	}
+
+	provider.account = fmt.Sprintf("%d", whoamiResponse.Data.Account.ID)
 
 	return provider, nil
 }

--- a/pkg/providers/dnssimple/dnssimple.go
+++ b/pkg/providers/dnssimple/dnssimple.go
@@ -2,6 +2,7 @@ package dnssimple
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"github.com/dnsimple/dnsimple-go/dnsimple"
@@ -83,7 +84,7 @@ func New(options schema.OptionBlock) (*Provider, error) {
 	}
 
 	if whoamiResponse.Data.Account != nil {
-		provider.account = whoamiResponse.Data.Account.ID
+		provider.account = fmt.Sprintf("%d", whoamiResponse.Data.Account.ID)
 	} else {
 		return nil, errorutil.New("no account information found in DNSSimple response")
 	}

--- a/pkg/providers/dnssimple/dnssimple.go
+++ b/pkg/providers/dnssimple/dnssimple.go
@@ -1,0 +1,108 @@
+package dnssimple
+
+import (
+	"context"
+	"strings"
+
+	"github.com/dnsimple/dnsimple-go/dnsimple"
+	"github.com/projectdiscovery/cloudlist/pkg/schema"
+	errorutil "github.com/projectdiscovery/utils/errors"
+)
+
+// Provider constants
+const (
+	providerName = "dnssimple"
+	apiToken     = "dnssimple_api_token"
+)
+
+var Services = []string{"dns"}
+
+// Provider is a data provider for DNSSimple API
+type Provider struct {
+	id       string
+	client   *dnsimple.Client
+	services schema.ServiceMap
+	account  string
+}
+
+// Name returns the name of the provider
+func (p *Provider) Name() string {
+	return providerName
+}
+
+// ID returns the name of the provider id
+func (p *Provider) ID() string {
+	return p.id
+}
+
+// Services returns the provider services
+func (p *Provider) Services() []string {
+	return p.services.Keys()
+}
+
+// New creates a new provider client for DNSSimple API
+func New(options schema.OptionBlock) (*Provider, error) {
+	token, ok := options.GetMetadata(apiToken)
+	if !ok {
+		return nil, &schema.ErrNoSuchKey{Name: apiToken}
+	}
+	id, _ := options.GetMetadata("id")
+
+	// Set up the client
+	client := dnsimple.NewClient(dnsimple.StaticTokenHTTPClient(context.Background(), token))
+
+	// Configure services
+	supportedServicesMap := make(map[string]struct{})
+	for _, s := range Services {
+		supportedServicesMap[s] = struct{}{}
+	}
+	services := make(schema.ServiceMap)
+	if ss, ok := options.GetMetadata("services"); ok {
+		for _, s := range strings.Split(ss, ",") {
+			if _, ok := supportedServicesMap[s]; ok {
+				services[s] = struct{}{}
+			}
+		}
+	}
+	if len(services) == 0 {
+		for _, s := range Services {
+			services[s] = struct{}{}
+		}
+	}
+
+	provider := &Provider{
+		id:       id,
+		client:   client,
+		services: services,
+	}
+
+	// Get and store account ID
+	whoamiResponse, err := client.Identity.Whoami(context.Background())
+	if err != nil {
+		return nil, errorutil.NewWithErr(err).Msgf("failed to authenticate with DNSSimple")
+	}
+
+	if whoamiResponse.Data.Account != nil {
+		provider.account = whoamiResponse.Data.Account.ID
+	} else {
+		return nil, errorutil.New("no account information found in DNSSimple response")
+	}
+
+	return provider, nil
+}
+
+// Resources returns all the resources from the DNSSimple provider
+func (p *Provider) Resources(ctx context.Context) (*schema.Resources, error) {
+	finalResources := schema.NewResources()
+
+	if p.services.Has("dns") {
+		dnsProvider := &dnsProvider{client: p.client, id: p.id, account: p.account}
+		zones, err := dnsProvider.GetResource(ctx)
+		if err != nil {
+			return nil, err
+		}
+		finalResources.Merge(zones)
+	}
+
+	return finalResources, nil
+}


### PR DESCRIPTION
# Add DNSSimple provider integration
This PR adds a new provider for DNSSimple, enabling users to enumerate DNS records from their DNSSimple accounts.

## Changes
- Implemented the DNSSimple provider with DNS record retrieval
- Added proper authentication using the DNSSimple API token
- Updated provider factory to include the new provider
- Added documentation in PROVIDERS.md with configuration examples

## Testing
To test this provider:
- Obtain a DNSSimple API token with read access to domains
- Configure the provider using either environment variables or direct configuration:
```bash
DNSSIMPLE_API_TOKEN
```
- Run cloudlist to enumerate DNS records from your DNSSimple account

```bash
./cloudlist -pc provider-config.yaml -p dnssimple

  _______             _____     __ 
 / ___/ /__  __ _____/ / (_)__ / /_
/ /__/ / _ \/ // / _  / / (_-</ __/
\___/_/\___/\_,_/\_,_/_/_/___/\__/ 

                projectdiscovery.io

[INF] Current cloudlist version 1.2.1 (latest)
[INF] Listing assets from provider: dnssimple services: dns id: main
..redacted
[INF] Found 2 Hosts and 16 IP Addresses for dnssimple (main)
```

## Dependencies
Added the official DNSSimple Go client: github.com/dnsimple/dnsimple-go/dnsimple

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced integration for the DNSSimple provider, enabling enhanced DNS management capabilities.

- **Documentation**
  - Updated configuration guides to include setup instructions and necessary API token details for the DNSSimple provider.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->