### PR TITLE
fix: handle api errors for gcp and cloudflare failure

### DIFF
--- a/pkg/providers/cloudflare/cloudflare.go
+++ b/pkg/providers/cloudflare/cloudflare.go
@@ -13,7 +13,7 @@ var Services = []string{"dns"}
 // Provider is a data provider for cloudflare API
 type Provider struct {
 	id               string
-	client           *cloudflare.API
+	client           apiClient
 	services         schema.ServiceMap
 	extendedMetadata bool
 }
@@ -103,9 +103,11 @@ func (p *Provider) Resources(ctx context.Context) (*schema.Resources, error) {
 
 	if p.services.Has("dns") {
 		dnsProvider := &dnsProvider{id: p.id, client: p.client, extendedMetadata: p.extendedMetadata}
-		if resources, err := dnsProvider.GetResource(ctx); err == nil {
-			finalResources.Merge(resources)
+		resources, err := dnsProvider.GetResource(ctx)
+		if err != nil {
+			return nil, err
 		}
+		finalResources.Merge(resources)
 	}
 	return finalResources, nil
 }

--- a/pkg/providers/cloudflare/cloudflare_test.go
+++ b/pkg/providers/cloudflare/cloudflare_test.go
@@ -1,0 +1,69 @@
+package cloudflare
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/cloudflare/cloudflare-go"
+	"github.com/projectdiscovery/cloudlist/pkg/schema"
+	"github.com/stretchr/testify/require"
+)
+
+type failingZonesClient struct {
+	err error
+}
+
+func (f *failingZonesClient) ListZones(context.Context, ...string) ([]cloudflare.Zone, error) {
+	return nil, f.err
+}
+
+func (f *failingZonesClient) ListDNSRecords(context.Context, *cloudflare.ResourceContainer, cloudflare.ListDNSRecordsParams) ([]cloudflare.DNSRecord, *cloudflare.ResultInfo, error) {
+	return nil, nil, nil
+}
+
+type failingRecordsClient struct {
+	zones []cloudflare.Zone
+	err   error
+}
+
+func (f *failingRecordsClient) ListZones(context.Context, ...string) ([]cloudflare.Zone, error) {
+	return f.zones, nil
+}
+
+func (f *failingRecordsClient) ListDNSRecords(context.Context, *cloudflare.ResourceContainer, cloudflare.ListDNSRecordsParams) ([]cloudflare.DNSRecord, *cloudflare.ResultInfo, error) {
+	return nil, nil, f.err
+}
+
+func TestProviderResourcesPropagatesZoneError(t *testing.T) {
+	t.Parallel()
+
+	p := &Provider{
+		id: "test",
+		client: &failingZonesClient{
+			err: errors.New("zones down"),
+		},
+		services: schema.ServiceMap{"dns": struct{}{}},
+	}
+
+	_, err := p.Resources(context.Background())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "zones down")
+}
+
+func TestProviderResourcesPropagatesRecordError(t *testing.T) {
+	t.Parallel()
+
+	p := &Provider{
+		id: "test",
+		client: &failingRecordsClient{
+			zones: []cloudflare.Zone{{ID: "zone-id"}},
+			err:   errors.New("record fetch failed"),
+		},
+		services: schema.ServiceMap{"dns": struct{}{}},
+	}
+
+	_, err := p.Resources(context.Background())
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "record fetch failed")
+}

--- a/pkg/providers/cloudflare/dns.go
+++ b/pkg/providers/cloudflare/dns.go
@@ -11,10 +11,14 @@ import (
 	"github.com/projectdiscovery/cloudlist/pkg/schema"
 )
 
-// dnsProvider is a provider for cloudflare dns resources
+type apiClient interface {
+	ListZones(ctx context.Context, opts ...string) ([]cloudflare.Zone, error)
+	ListDNSRecords(ctx context.Context, zoneID *cloudflare.ResourceContainer, params cloudflare.ListDNSRecordsParams) ([]cloudflare.DNSRecord, *cloudflare.ResultInfo, error)
+}
+
 type dnsProvider struct {
 	id               string
-	client           *cloudflare.API
+	client           apiClient
 	extendedMetadata bool
 }
 

--- a/pkg/providers/gcp/gcp.go
+++ b/pkg/providers/gcp/gcp.go
@@ -87,6 +87,7 @@ func (p *Provider) Services() []string {
 // Resources returns the provider for an resource deployment source using individual services
 func (p *Provider) Resources(ctx context.Context) (*schema.Resources, error) {
 	finalResources := schema.NewResources()
+	var errs []error
 
 	if p.services.Has("dns") {
 		dnsProvider := &cloudDNSProvider{
@@ -98,6 +99,7 @@ func (p *Provider) Resources(ctx context.Context) (*schema.Resources, error) {
 		dnsResources, err := dnsProvider.GetResource(ctx)
 		if err != nil {
 			gologger.Warning().Msgf("Could not get DNS resources: %s\n", err)
+			errs = append(errs, fmt.Errorf("dns: %w", err))
 		} else {
 			finalResources.Merge(dnsResources)
 		}
@@ -113,6 +115,7 @@ func (p *Provider) Resources(ctx context.Context) (*schema.Resources, error) {
 		computeResources, err := computeProvider.GetResource(ctx)
 		if err != nil {
 			gologger.Warning().Msgf("Could not get compute resources: %s\n", err)
+			errs = append(errs, fmt.Errorf("compute: %w", err))
 		} else {
 			finalResources.Merge(computeResources)
 		}
@@ -128,6 +131,7 @@ func (p *Provider) Resources(ctx context.Context) (*schema.Resources, error) {
 		gkeResources, err := gkeProvider.GetResource(ctx)
 		if err != nil {
 			gologger.Warning().Msgf("Could not get gke resources: %s\n", err)
+			errs = append(errs, fmt.Errorf("gke: %w", err))
 		} else {
 			finalResources.Merge(gkeResources)
 		}
@@ -143,6 +147,7 @@ func (p *Provider) Resources(ctx context.Context) (*schema.Resources, error) {
 		storageResources, err := storageProvider.GetResource(ctx)
 		if err != nil {
 			gologger.Warning().Msgf("Could not get storage resources: %s\n", err)
+			errs = append(errs, fmt.Errorf("storage: %w", err))
 		} else {
 			finalResources.Merge(storageResources)
 		}
@@ -158,6 +163,7 @@ func (p *Provider) Resources(ctx context.Context) (*schema.Resources, error) {
 		functionResources, err := functionProvider.GetResource(ctx)
 		if err != nil {
 			gologger.Warning().Msgf("Could not get function resources: %s\n", err)
+			errs = append(errs, fmt.Errorf("cloud-function: %w", err))
 		} else {
 			finalResources.Merge(functionResources)
 		}
@@ -173,9 +179,14 @@ func (p *Provider) Resources(ctx context.Context) (*schema.Resources, error) {
 		runResources, err := runProvider.GetResource(ctx)
 		if err != nil {
 			gologger.Warning().Msgf("Could not get run resources: %s\n", err)
+			errs = append(errs, fmt.Errorf("cloud-run: %w", err))
 		} else {
 			finalResources.Merge(runResources)
 		}
+	}
+
+	if len(finalResources.Items) == 0 && len(errs) > 0 {
+		return nil, errs[0]
 	}
 
 	return finalResources, nil

--- a/pkg/providers/gcp/gcp.go
+++ b/pkg/providers/gcp/gcp.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strconv"
 	"strings"
+	"time"
 
 	asset "cloud.google.com/go/asset/apiv1"
 	assetpb "cloud.google.com/go/asset/apiv1/assetpb"
@@ -22,6 +24,7 @@ import (
 	run "google.golang.org/api/run/v1"
 	"google.golang.org/api/storage/v1"
 	"google.golang.org/protobuf/types/known/structpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 // Provider is a data provider for gcp API
@@ -41,19 +44,20 @@ type Provider struct {
 
 // OrganizationProvider is a provider for organization-level GCP Asset API
 type OrganizationProvider struct {
-	id               string
-	organizationID   string
-	assetClient      *asset.Client
-	services         schema.ServiceMap
-	projects         []string
-	extendedMetadata bool
-	compute          *compute.Service // For extended metadata
-	functionsV1      *cloudfunctionsv1.Service
-	functionsV2      *cloudfunctions.Service
-	run              *run.APIService
-	dns              *dns.Service
-	storage          *storage.Service
-	gke              *container.Service
+	id                    string
+	organizationID        string
+	assetClient           *asset.Client
+	services              schema.ServiceMap
+	projects              []string
+	extendedMetadata      bool
+	readTimeOffsetSeconds int
+	compute               *compute.Service // For extended metadata
+	functionsV1           *cloudfunctionsv1.Service
+	functionsV2           *cloudfunctions.Service
+	run                   *run.APIService
+	dns                   *dns.Service
+	storage               *storage.Service
+	gke                   *container.Service
 }
 
 // Services that provide IP addresses or DNS names only
@@ -401,6 +405,10 @@ func (p *OrganizationProvider) Resources(ctx context.Context) (*schema.Resources
 // getAllAssets gets all assets using the Cloud Asset Inventory API
 func (p *OrganizationProvider) getAllAssets(ctx context.Context, parent string) (*schema.Resources, error) {
 	gologger.Info().Msgf("Starting Asset API discovery for parent: %s", parent)
+	if p.readTimeOffsetSeconds > 0 {
+		readTime := time.Now().Add(-time.Duration(p.readTimeOffsetSeconds) * time.Second).UTC().Format(time.RFC3339)
+		gologger.Info().Msgf("Using read time offset of %d seconds (read_time=%s)", p.readTimeOffsetSeconds, readTime)
+	}
 
 	var assetTypesGcpListAPI = []string{
 		"compute.googleapis.com/Instance",
@@ -434,6 +442,15 @@ func (p *OrganizationProvider) getAssetsForTypes(ctx context.Context, parent str
 		AssetTypes:  assetTypes,
 		ContentType: assetpb.ContentType_RESOURCE,
 		PageSize:    1000,
+	}
+
+	if p.readTimeOffsetSeconds > 0 {
+		now := time.Now()
+		readTime := now.Add(-time.Duration(p.readTimeOffsetSeconds) * time.Second)
+		if readTime.After(now) {
+			readTime = now
+		}
+		req.ReadTime = timestamppb.New(readTime)
 	}
 
 	resources := schema.NewResources()
@@ -514,6 +531,11 @@ func newOrganizationProvider(options schema.OptionBlock, id, JSONData, organizat
 	// Check for extended metadata flag
 	if extendedMetadata, ok := options.GetMetadata("extended_metadata"); ok {
 		provider.extendedMetadata = extendedMetadata == "true"
+	}
+	if offsetStr, ok := options.GetMetadata("read_time_offset_seconds"); ok {
+		if offset, err := strconv.Atoi(offsetStr); err == nil && offset > 0 {
+			provider.readTimeOffsetSeconds = offset
+		}
 	}
 
 	// Get all available services for organization-level discovery


### PR DESCRIPTION
closes: #712 
- Updated the cloudflare provider to use a more flexible apiClient interface instead of the specific cloudflare.API type.
- Improved error handling in the Resources method to return errors directly from the DNS provider.
- Ensured that resources are merged only after successful retrieval, enhancing the reliability of resource management.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added read-time offset support for GCP organization-level resource discovery.

* **Bug Fixes**
  * Improved error handling and propagation in Cloudflare provider.
  * Enhanced error reporting in GCP provider for better visibility into service failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->