### PR TITLE
Self discovery mode

### DIFF
--- a/cmd/cloudlist/main.go
+++ b/cmd/cloudlist/main.go
@@ -11,5 +11,8 @@ func main() {
 	if err != nil {
 		gologger.Fatal().Msgf("Could not create runner: %s\n", err)
 	}
+	if runner == nil {
+		return
+	}
 	runner.Enumerate()
 }

--- a/internal/runner/autodiscovery.go
+++ b/internal/runner/autodiscovery.go
@@ -15,39 +15,39 @@ import (
 	fileutil "github.com/projectdiscovery/utils/file"
 )
 
-// SelfDiscovery handles auto-discovery of cloud providers from environment variables
-type SelfDiscovery struct {
+// AutoDiscovery handles auto-discovery of cloud providers from environment variables
+type AutoDiscovery struct {
 	options *Options
 }
 
-// NewSelfDiscovery creates a new self-discovery instance
-func NewSelfDiscovery(options *Options) *SelfDiscovery {
-	return &SelfDiscovery{options: options}
+// NewAutoDiscovery creates a new auto-discovery instance
+func NewAutoDiscovery(options *Options) *AutoDiscovery {
+	return &AutoDiscovery{options: options}
 }
 
 // DiscoverProviders attempts to auto-discover available providers from environment
-func (sd *SelfDiscovery) DiscoverProviders() schema.Options {
+func (ad *AutoDiscovery) DiscoverProviders() schema.Options {
 	discoveredConfig := schema.Options{}
 
 	// Check which providers to discover
-	providersToCheck := sd.getProvidersToCheck()
+	providersToCheck := ad.getProvidersToCheck()
 
 	for _, provider := range providersToCheck {
 		switch provider {
 		case "kubernetes":
-			if config := sd.discoverKubernetes(); config != nil {
+			if config := ad.discoverKubernetes(); config != nil {
 				discoveredConfig = append(discoveredConfig, config)
 			}
 		case "aws":
-			if config := sd.discoverAWS(); config != nil {
+			if config := ad.discoverAWS(); config != nil {
 				discoveredConfig = append(discoveredConfig, config)
 			}
 		case "gcp":
-			if config := sd.discoverGCP(); config != nil {
+			if config := ad.discoverGCP(); config != nil {
 				discoveredConfig = append(discoveredConfig, config)
 			}
 		case "azure":
-			if config := sd.discoverAzure(); config != nil {
+			if config := ad.discoverAzure(); config != nil {
 				discoveredConfig = append(discoveredConfig, config)
 			}
 		}
@@ -57,10 +57,10 @@ func (sd *SelfDiscovery) DiscoverProviders() schema.Options {
 }
 
 // getProvidersToCheck returns the list of providers to check
-func (sd *SelfDiscovery) getProvidersToCheck() []string {
+func (ad *AutoDiscovery) getProvidersToCheck() []string {
 	// If specific providers are requested, use those
-	if len(sd.options.Providers) > 0 {
-		return sd.options.Providers
+	if len(ad.options.Providers) > 0 {
+		return ad.options.Providers
 	}
 
 	// Otherwise, check all supported providers
@@ -68,7 +68,7 @@ func (sd *SelfDiscovery) getProvidersToCheck() []string {
 }
 
 // discoverKubernetes attempts to discover Kubernetes configuration
-func (sd *SelfDiscovery) discoverKubernetes() schema.OptionBlock {
+func (ad *AutoDiscovery) discoverKubernetes() schema.OptionBlock {
 	var kubeconfigPath string
 
 	// Check KUBECONFIG environment variable first
@@ -83,7 +83,7 @@ func (sd *SelfDiscovery) discoverKubernetes() schema.OptionBlock {
 		// Fallback to default kubeconfig location
 		homeDir, err := os.UserHomeDir()
 		if err != nil {
-			if sd.options.Verbose {
+			if ad.options.Verbose {
 				gologger.Verbose().Msgf("Could not get user home directory: %s\n", err)
 			}
 			return nil
@@ -96,14 +96,14 @@ func (sd *SelfDiscovery) discoverKubernetes() schema.OptionBlock {
 		gologger.Info().Msgf("Discovered Kubernetes provider (in-cluster mode)\n")
 		return schema.OptionBlock{
 			"provider":       "kubernetes",
-			"id":             "self-discovery",
+			"id":             "auto-discovery",
 			"incluster_mode": "true",
 		}
 	}
 
 	// Check if kubeconfig file exists
 	if !fileutil.FileExists(kubeconfigPath) {
-		if sd.options.Verbose {
+		if ad.options.Verbose {
 			gologger.Verbose().Msgf("Kubeconfig file not found at: %s\n", kubeconfigPath)
 		}
 		return nil
@@ -113,20 +113,20 @@ func (sd *SelfDiscovery) discoverKubernetes() schema.OptionBlock {
 
 	return schema.OptionBlock{
 		"provider":        "kubernetes",
-		"id":              "self-discovery",
+		"id":              "auto-discovery",
 		"kubeconfig_file": kubeconfigPath,
 	}
 }
 
 // discoverAWS attempts to discover AWS credentials
-func (sd *SelfDiscovery) discoverAWS() schema.OptionBlock {
+func (ad *AutoDiscovery) discoverAWS() schema.OptionBlock {
 	// Priority 1: Check AWS IMDS (EC2/ECS instance metadata)
-	if config := sd.tryAWSIMDS(); config != nil {
+	if config := ad.tryAWSIMDS(); config != nil {
 		return config
 	}
 
 	// Priority 2: Check ECS container credentials
-	if config := sd.tryAWSECSCredentials(); config != nil {
+	if config := ad.tryAWSECSCredentials(); config != nil {
 		return config
 	}
 
@@ -141,7 +141,7 @@ func (sd *SelfDiscovery) discoverAWS() schema.OptionBlock {
 
 		config := schema.OptionBlock{
 			"provider":       "aws",
-			"id":             "self-discovery",
+			"id":             "auto-discovery",
 			"aws_access_key": accessKey,
 			"aws_secret_key": secretKey,
 		}
@@ -163,12 +163,12 @@ func (sd *SelfDiscovery) discoverAWS() schema.OptionBlock {
 	awsConfigPath := filepath.Join(homeDir, ".aws", "config")
 
 	if fileutil.FileExists(awsCredsPath) || fileutil.FileExists(awsConfigPath) {
-		if sd.options.Verbose {
+		if ad.options.Verbose {
 			gologger.Verbose().Msgf("AWS credentials file found, but direct env variables not set\n")
 			gologger.Verbose().Msgf("Please set AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY or use provider config\n")
 			profile := os.Getenv("AWS_PROFILE")
 			if profile != "" {
-				gologger.Verbose().Msgf("AWS_PROFILE detected: %s (not yet supported in self-discovery)\n", profile)
+				gologger.Verbose().Msgf("AWS_PROFILE detected: %s (not yet supported in auto-discovery)\n", profile)
 			}
 		}
 	}
@@ -177,7 +177,7 @@ func (sd *SelfDiscovery) discoverAWS() schema.OptionBlock {
 }
 
 // tryAWSIMDS attempts to get credentials from AWS EC2 Instance Metadata Service
-func (sd *SelfDiscovery) tryAWSIMDS() schema.OptionBlock {
+func (ad *AutoDiscovery) tryAWSIMDS() schema.OptionBlock {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 
@@ -196,12 +196,12 @@ func (sd *SelfDiscovery) tryAWSIMDS() schema.OptionBlock {
 		token, err := io.ReadAll(tokenResp.Body)
 		if err == nil && len(token) > 0 {
 			// We have IMDSv2 available
-			if sd.hasValidIMDSRole(client, string(token)) {
+			if ad.hasValidIMDSRole(client, string(token)) {
 				gologger.Info().Msgf("Discovered AWS provider (EC2 instance with IAM role - IMDSv2)\n")
 				// AWS SDK will automatically use IMDS when no credentials are provided
 				return schema.OptionBlock{
 					"provider": "aws",
-					"id":       "self-discovery",
+					"id":       "auto-discovery",
 					"use_imds": "true",
 				}
 			}
@@ -225,7 +225,7 @@ func (sd *SelfDiscovery) tryAWSIMDS() schema.OptionBlock {
 		// AWS SDK will automatically use IMDS when no credentials are provided
 		return schema.OptionBlock{
 			"provider": "aws",
-			"id":       "self-discovery",
+			"id":       "auto-discovery",
 			"use_imds": "true",
 		}
 	}
@@ -234,7 +234,7 @@ func (sd *SelfDiscovery) tryAWSIMDS() schema.OptionBlock {
 }
 
 // hasValidIMDSRole checks if there's a valid IAM role attached
-func (sd *SelfDiscovery) hasValidIMDSRole(client *http.Client, token string) bool {
+func (ad *AutoDiscovery) hasValidIMDSRole(client *http.Client, token string) bool {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 
@@ -259,7 +259,7 @@ func (sd *SelfDiscovery) hasValidIMDSRole(client *http.Client, token string) boo
 }
 
 // tryAWSECSCredentials attempts to get credentials from ECS task role
-func (sd *SelfDiscovery) tryAWSECSCredentials() schema.OptionBlock {
+func (ad *AutoDiscovery) tryAWSECSCredentials() schema.OptionBlock {
 	// Check if running in ECS
 	credentialsURI := os.Getenv("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI")
 	if credentialsURI == "" {
@@ -273,15 +273,15 @@ func (sd *SelfDiscovery) tryAWSECSCredentials() schema.OptionBlock {
 	gologger.Info().Msgf("Discovered AWS provider (ECS task with IAM role)\n")
 	return schema.OptionBlock{
 		"provider":          "aws",
-		"id":                "self-discovery",
+		"id":                "auto-discovery",
 		"use_ecs_task_role": "true",
 	}
 }
 
 // discoverGCP attempts to discover GCP credentials
-func (sd *SelfDiscovery) discoverGCP() schema.OptionBlock {
+func (ad *AutoDiscovery) discoverGCP() schema.OptionBlock {
 	// Priority 1: Check GCP Metadata Service (GCE/GKE instance)
-	if config := sd.tryGCPMetadataService(); config != nil {
+	if config := ad.tryGCPMetadataService(); config != nil {
 		return config
 	}
 
@@ -298,7 +298,7 @@ func (sd *SelfDiscovery) discoverGCP() schema.OptionBlock {
 	}
 
 	if !fileutil.FileExists(credsPath) {
-		if sd.options.Verbose {
+		if ad.options.Verbose {
 			gologger.Verbose().Msgf("GCP credentials not found at: %s\n", credsPath)
 		}
 		return nil
@@ -307,7 +307,7 @@ func (sd *SelfDiscovery) discoverGCP() schema.OptionBlock {
 	// Read the service account key file
 	keyData, err := os.ReadFile(credsPath)
 	if err != nil {
-		if sd.options.Verbose {
+		if ad.options.Verbose {
 			gologger.Verbose().Msgf("Could not read GCP credentials file: %s\n", err)
 		}
 		return nil
@@ -317,13 +317,13 @@ func (sd *SelfDiscovery) discoverGCP() schema.OptionBlock {
 
 	return schema.OptionBlock{
 		"provider":                "gcp",
-		"id":                      "self-discovery",
+		"id":                      "auto-discovery",
 		"gcp_service_account_key": string(keyData),
 	}
 }
 
 // tryGCPMetadataService attempts to get credentials from GCP Metadata Service
-func (sd *SelfDiscovery) tryGCPMetadataService() schema.OptionBlock {
+func (ad *AutoDiscovery) tryGCPMetadataService() schema.OptionBlock {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 
@@ -355,7 +355,7 @@ func (sd *SelfDiscovery) tryGCPMetadataService() schema.OptionBlock {
 					// which automatically uses metadata service
 					return schema.OptionBlock{
 						"provider":                "gcp",
-						"id":                      "self-discovery",
+						"id":                      "auto-discovery",
 						"gcp_service_account_key": "",
 					}
 				}
@@ -367,9 +367,9 @@ func (sd *SelfDiscovery) tryGCPMetadataService() schema.OptionBlock {
 }
 
 // discoverAzure attempts to discover Azure credentials
-func (sd *SelfDiscovery) discoverAzure() schema.OptionBlock {
+func (ad *AutoDiscovery) discoverAzure() schema.OptionBlock {
 	// Priority 1: Check Azure Managed Identity (MSI)
-	if config := sd.tryAzureManagedIdentity(); config != nil {
+	if config := ad.tryAzureManagedIdentity(); config != nil {
 		return config
 	}
 
@@ -384,7 +384,7 @@ func (sd *SelfDiscovery) discoverAzure() schema.OptionBlock {
 
 		return schema.OptionBlock{
 			"provider":        "azure",
-			"id":              "self-discovery",
+			"id":              "auto-discovery",
 			"client_id":       clientID,
 			"client_secret":   clientSecret,
 			"tenant_id":       tenantID,
@@ -406,13 +406,13 @@ func (sd *SelfDiscovery) discoverAzure() schema.OptionBlock {
 
 			return schema.OptionBlock{
 				"provider":        "azure",
-				"id":              "self-discovery",
+				"id":              "auto-discovery",
 				"subscription_id": subscriptionID,
 				"use_cli_auth":    "true",
 			}
 		}
 
-		if sd.options.Verbose {
+		if ad.options.Verbose {
 			gologger.Verbose().Msgf("Azure CLI configuration found, but AZURE_SUBSCRIPTION_ID not set\n")
 		}
 	}
@@ -421,7 +421,7 @@ func (sd *SelfDiscovery) discoverAzure() schema.OptionBlock {
 }
 
 // tryAzureManagedIdentity attempts to get credentials from Azure Managed Identity
-func (sd *SelfDiscovery) tryAzureManagedIdentity() schema.OptionBlock {
+func (ad *AutoDiscovery) tryAzureManagedIdentity() schema.OptionBlock {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 
@@ -445,7 +445,7 @@ func (sd *SelfDiscovery) tryAzureManagedIdentity() schema.OptionBlock {
 					subscriptionID := os.Getenv("AZURE_SUBSCRIPTION_ID")
 					config := schema.OptionBlock{
 						"provider": "azure",
-						"id":       "self-discovery",
+						"id":       "auto-discovery",
 					}
 					if subscriptionID != "" {
 						config["subscription_id"] = subscriptionID
@@ -473,7 +473,7 @@ func (sd *SelfDiscovery) tryAzureManagedIdentity() schema.OptionBlock {
 					subscriptionID := os.Getenv("AZURE_SUBSCRIPTION_ID")
 					config := schema.OptionBlock{
 						"provider": "azure",
-						"id":       "self-discovery",
+						"id":       "auto-discovery",
 					}
 					if subscriptionID != "" {
 						config["subscription_id"] = subscriptionID
@@ -508,7 +508,7 @@ func (sd *SelfDiscovery) tryAzureManagedIdentity() schema.OptionBlock {
 					subscriptionID := os.Getenv("AZURE_SUBSCRIPTION_ID")
 					config := schema.OptionBlock{
 						"provider": "azure",
-						"id":       "self-discovery",
+						"id":       "auto-discovery",
 					}
 					if subscriptionID != "" {
 						config["subscription_id"] = subscriptionID

--- a/internal/runner/options.go
+++ b/internal/runner/options.go
@@ -35,7 +35,7 @@ type Options struct {
 	ExtendedMetadata   bool                // ExtendedMetadata enables extended metadata for providers.
 	ProviderConfig     string              // ProviderConfig is the location of the provider config file.
 	DisableUpdateCheck bool                // DisableUpdateCheck disable automatic update check
-	SelfDiscovery      bool                // SelfDiscovery enables auto-discovery of providers from environment variables
+	AutoDiscovery      bool                // AutoDiscovery enables auto-discovery of providers from environment variables
 }
 
 var (
@@ -78,7 +78,7 @@ func ParseOptions() *Options {
 	flagSet.CreateGroup("config", "Configuration",
 		flagSet.StringVar(&options.Config, "config", defaultConfigLocation, "cloudlist flag config file"),
 		flagSet.StringVarP(&options.ProviderConfig, "provider-config", "pc", defaultProviderConfigLocation, "provider config file"),
-		flagSet.BoolVarP(&options.SelfDiscovery, "self-discovery", "sd", false, "enable self-discovery mode to auto-detect providers from environment"),
+		flagSet.BoolVarP(&options.AutoDiscovery, "auto-discovery", "ad", false, "enable auto-discovery mode to auto-detect providers from environment"),
 	)
 	flagSet.CreateGroup("filter", "Filters",
 		flagSet.StringSliceVarP(&options.Providers, "provider", "p", nil, "display results for given providers (comma-separated) (default "+strings.Join(defaultProviders, ",")+")", goflags.CommaSeparatedStringSliceOptions),

--- a/internal/runner/options.go
+++ b/internal/runner/options.go
@@ -35,6 +35,7 @@ type Options struct {
 	ExtendedMetadata   bool                // ExtendedMetadata enables extended metadata for providers.
 	ProviderConfig     string              // ProviderConfig is the location of the provider config file.
 	DisableUpdateCheck bool                // DisableUpdateCheck disable automatic update check
+	SelfDiscovery      bool                // SelfDiscovery enables auto-discovery of providers from environment variables
 }
 
 var (
@@ -77,6 +78,7 @@ func ParseOptions() *Options {
 	flagSet.CreateGroup("config", "Configuration",
 		flagSet.StringVar(&options.Config, "config", defaultConfigLocation, "cloudlist flag config file"),
 		flagSet.StringVarP(&options.ProviderConfig, "provider-config", "pc", defaultProviderConfigLocation, "provider config file"),
+		flagSet.BoolVarP(&options.SelfDiscovery, "self-discovery", "sd", false, "enable self-discovery mode to auto-detect providers from environment"),
 	)
 	flagSet.CreateGroup("filter", "Filters",
 		flagSet.StringSliceVarP(&options.Providers, "provider", "p", nil, "display results for given providers (comma-separated) (default "+strings.Join(defaultProviders, ",")+")", goflags.CommaSeparatedStringSliceOptions),

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -104,9 +104,24 @@ func (r *Runner) Enumerate() {
 		}
 	}
 
-	inventory, err := inventory.New(finalConfig)
-	if err != nil {
-		gologger.Fatal().Msgf("Could not create inventory: %s\n", err)
+	// In auto-discovery mode, use graceful failure to skip providers with errors
+	var inv *inventory.Inventory
+	var err error
+	if r.options.AutoDiscovery {
+		inv, err = inventory.NewWithOptions(finalConfig, true, r.options.Verbose)
+		if err != nil {
+			gologger.Fatal().Msgf("Could not create inventory: %s\n", err)
+		}
+		// Check if we have any providers after graceful failure
+		if len(inv.Providers) == 0 {
+			gologger.Warning().Msgf("No providers could be initialized successfully\n")
+			return
+		}
+	} else {
+		inv, err = inventory.New(finalConfig)
+		if err != nil {
+			gologger.Fatal().Msgf("Could not create inventory: %s\n", err)
+		}
 	}
 
 	var output *os.File
@@ -120,7 +135,7 @@ func (r *Runner) Enumerate() {
 
 	builder := &bytes.Buffer{}
 	deduplicator := schema.NewResourceDeduplicator()
-	for _, provider := range inventory.Providers {
+	for _, provider := range inv.Providers {
 		gologger.Info().Msgf("Listing assets from provider: %s services: %s id: %s", provider.Name(), strings.Join(provider.Services(), ","), provider.ID())
 
 		instances, err := provider.Resources(context.Background())

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -23,15 +23,15 @@ type Runner struct {
 func New(options *Options) (*Runner, error) {
 	var config schema.Options
 
-	// If self-discovery mode is enabled, skip provider config file
-	if options.SelfDiscovery {
-		gologger.Info().Msgf("Self-discovery mode enabled, ignoring provider config file\n")
+	// If auto-discovery mode is enabled, skip provider config file
+	if options.AutoDiscovery {
+		gologger.Info().Msgf("Auto-discovery mode enabled, ignoring provider config file\n")
 
-		sd := NewSelfDiscovery(options)
-		config = sd.DiscoverProviders()
+		ad := NewAutoDiscovery(options)
+		config = ad.DiscoverProviders()
 
 		if len(config) == 0 {
-			gologger.Warning().Msgf("No providers discovered in self-discovery mode\n")
+			gologger.Warning().Msgf("No providers discovered in auto-discovery mode\n")
 			gologger.Info().Msgf("Hint: Make sure you have KUBECONFIG set or ~/.kube/config exists for Kubernetes\n")
 			gologger.Info().Msgf("Hint: Set AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY for AWS\n")
 			gologger.Info().Msgf("Hint: Set GOOGLE_APPLICATION_CREDENTIALS for GCP\n")
@@ -61,7 +61,7 @@ func New(options *Options) (*Runner, error) {
 	if len(options.Services) == 0 {
 		options.Services = append(options.Services, defaultServies...)
 	}
-	if len(options.Providers) == 0 && !options.SelfDiscovery {
+	if len(options.Providers) == 0 && !options.AutoDiscovery {
 		options.Providers = append(options.Providers, defaultProviders...)
 	}
 

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -21,15 +21,35 @@ type Runner struct {
 
 // New creates a new runner instance based on configuration options
 func New(options *Options) (*Runner, error) {
+	var config schema.Options
 
-	if options.ProviderConfig == "" {
-		options.ProviderConfig = defaultProviderConfigLocation
-		gologger.Print().Msgf("Using default provider config: %s\n", options.ProviderConfig)
-	}
+	// If self-discovery mode is enabled, skip provider config file
+	if options.SelfDiscovery {
+		gologger.Info().Msgf("Self-discovery mode enabled, ignoring provider config file\n")
 
-	config, err := readProviderConfig(options.ProviderConfig)
-	if err != nil {
-		return nil, err
+		sd := NewSelfDiscovery(options)
+		config = sd.DiscoverProviders()
+
+		if len(config) == 0 {
+			gologger.Warning().Msgf("No providers discovered in self-discovery mode\n")
+			gologger.Info().Msgf("Hint: Make sure you have KUBECONFIG set or ~/.kube/config exists for Kubernetes\n")
+			gologger.Info().Msgf("Hint: Set AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY for AWS\n")
+			gologger.Info().Msgf("Hint: Set GOOGLE_APPLICATION_CREDENTIALS for GCP\n")
+			gologger.Info().Msgf("Hint: Set AZURE_CLIENT_ID/AZURE_CLIENT_SECRET/AZURE_TENANT_ID/AZURE_SUBSCRIPTION_ID for Azure\n")
+			return nil, nil
+		}
+	} else {
+		// Normal mode: read from provider config file
+		if options.ProviderConfig == "" {
+			options.ProviderConfig = defaultProviderConfigLocation
+			gologger.Print().Msgf("Using default provider config: %s\n", options.ProviderConfig)
+		}
+
+		var err error
+		config, err = readProviderConfig(options.ProviderConfig)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	// CLI overrides config
@@ -41,7 +61,7 @@ func New(options *Options) (*Runner, error) {
 	if len(options.Services) == 0 {
 		options.Services = append(options.Services, defaultServies...)
 	}
-	if len(options.Providers) == 0 {
+	if len(options.Providers) == 0 && !options.SelfDiscovery {
 		options.Providers = append(options.Providers, defaultProviders...)
 	}
 

--- a/internal/runner/selfdiscovery.go
+++ b/internal/runner/selfdiscovery.go
@@ -1,9 +1,14 @@
 package runner
 
 import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/projectdiscovery/cloudlist/pkg/schema"
 	"github.com/projectdiscovery/gologger"
@@ -115,13 +120,20 @@ func (sd *SelfDiscovery) discoverKubernetes() schema.OptionBlock {
 
 // discoverAWS attempts to discover AWS credentials
 func (sd *SelfDiscovery) discoverAWS() schema.OptionBlock {
-	// Check for AWS credentials in environment
+	// Priority 1: Check AWS IMDS (EC2/ECS instance metadata)
+	if config := sd.tryAWSIMDS(); config != nil {
+		return config
+	}
+
+	// Priority 2: Check ECS container credentials
+	if config := sd.tryAWSECSCredentials(); config != nil {
+		return config
+	}
+
+	// Priority 3: Check for AWS credentials in environment
 	accessKey := os.Getenv("AWS_ACCESS_KEY_ID")
 	secretKey := os.Getenv("AWS_SECRET_ACCESS_KEY")
 	sessionToken := os.Getenv("AWS_SESSION_TOKEN")
-
-	// Also check for AWS profile
-	profile := os.Getenv("AWS_PROFILE")
 
 	// If we have access key and secret key, we can proceed
 	if accessKey != "" && secretKey != "" {
@@ -141,7 +153,7 @@ func (sd *SelfDiscovery) discoverAWS() schema.OptionBlock {
 		return config
 	}
 
-	// Check for AWS credentials file
+	// Priority 4: Check for AWS credentials file
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
 		return nil
@@ -154,6 +166,7 @@ func (sd *SelfDiscovery) discoverAWS() schema.OptionBlock {
 		if sd.options.Verbose {
 			gologger.Verbose().Msgf("AWS credentials file found, but direct env variables not set\n")
 			gologger.Verbose().Msgf("Please set AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY or use provider config\n")
+			profile := os.Getenv("AWS_PROFILE")
 			if profile != "" {
 				gologger.Verbose().Msgf("AWS_PROFILE detected: %s (not yet supported in self-discovery)\n", profile)
 			}
@@ -163,9 +176,116 @@ func (sd *SelfDiscovery) discoverAWS() schema.OptionBlock {
 	return nil
 }
 
+// tryAWSIMDS attempts to get credentials from AWS EC2 Instance Metadata Service
+func (sd *SelfDiscovery) tryAWSIMDS() schema.OptionBlock {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	client := &http.Client{Timeout: 2 * time.Second}
+
+	// Try IMDSv2 first (more secure, requires token)
+	tokenReq, err := http.NewRequestWithContext(ctx, "PUT", "http://169.254.169.254/latest/api/token", nil)
+	if err != nil {
+		return nil
+	}
+	tokenReq.Header.Set("X-aws-ec2-metadata-token-ttl-seconds", "21600")
+
+	tokenResp, err := client.Do(tokenReq)
+	if err == nil && tokenResp.StatusCode == 200 {
+		defer tokenResp.Body.Close()
+		token, err := io.ReadAll(tokenResp.Body)
+		if err == nil && len(token) > 0 {
+			// We have IMDSv2 available
+			if sd.hasValidIMDSRole(client, string(token)) {
+				gologger.Info().Msgf("Discovered AWS provider (EC2 instance with IAM role - IMDSv2)\n")
+				// AWS SDK will automatically use IMDS when no credentials are provided
+				return schema.OptionBlock{
+					"provider": "aws",
+					"id":       "self-discovery",
+					"use_imds": "true",
+				}
+			}
+		}
+	}
+
+	// Fallback to IMDSv1
+	roleReq, err := http.NewRequestWithContext(ctx, "GET", "http://169.254.169.254/latest/meta-data/iam/security-credentials/", nil)
+	if err != nil {
+		return nil
+	}
+
+	roleResp, err := client.Do(roleReq)
+	if err != nil {
+		return nil
+	}
+	defer roleResp.Body.Close()
+
+	if roleResp.StatusCode == 200 {
+		gologger.Info().Msgf("Discovered AWS provider (EC2 instance with IAM role - IMDSv1)\n")
+		// AWS SDK will automatically use IMDS when no credentials are provided
+		return schema.OptionBlock{
+			"provider": "aws",
+			"id":       "self-discovery",
+			"use_imds": "true",
+		}
+	}
+
+	return nil
+}
+
+// hasValidIMDSRole checks if there's a valid IAM role attached
+func (sd *SelfDiscovery) hasValidIMDSRole(client *http.Client, token string) bool {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, "GET", "http://169.254.169.254/latest/meta-data/iam/security-credentials/", nil)
+	if err != nil {
+		return false
+	}
+	req.Header.Set("X-aws-ec2-metadata-token", token)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return false
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return false
+	}
+
+	return resp.StatusCode == 200 && len(body) > 0
+}
+
+// tryAWSECSCredentials attempts to get credentials from ECS task role
+func (sd *SelfDiscovery) tryAWSECSCredentials() schema.OptionBlock {
+	// Check if running in ECS
+	credentialsURI := os.Getenv("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI")
+	if credentialsURI == "" {
+		// Also check for full URI (used in some configurations)
+		credentialsURI = os.Getenv("AWS_CONTAINER_CREDENTIALS_FULL_URI")
+		if credentialsURI == "" {
+			return nil
+		}
+	}
+
+	gologger.Info().Msgf("Discovered AWS provider (ECS task with IAM role)\n")
+	return schema.OptionBlock{
+		"provider":          "aws",
+		"id":                "self-discovery",
+		"use_ecs_task_role": "true",
+	}
+}
+
 // discoverGCP attempts to discover GCP credentials
 func (sd *SelfDiscovery) discoverGCP() schema.OptionBlock {
-	// Check for GCP application credentials
+	// Priority 1: Check GCP Metadata Service (GCE/GKE instance)
+	if config := sd.tryGCPMetadataService(); config != nil {
+		return config
+	}
+
+	// Priority 2: Check for GCP application credentials from environment
 	credsPath := os.Getenv("GOOGLE_APPLICATION_CREDENTIALS")
 
 	if credsPath == "" {
@@ -202,9 +322,58 @@ func (sd *SelfDiscovery) discoverGCP() schema.OptionBlock {
 	}
 }
 
+// tryGCPMetadataService attempts to get credentials from GCP Metadata Service
+func (sd *SelfDiscovery) tryGCPMetadataService() schema.OptionBlock {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	client := &http.Client{Timeout: 2 * time.Second}
+
+	// Try to access GCP metadata service
+	req, err := http.NewRequestWithContext(ctx, "GET", "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token", nil)
+	if err != nil {
+		return nil
+	}
+	req.Header.Set("Metadata-Flavor", "Google")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == 200 {
+		// Verify it's actually GCP by checking the response
+		body, err := io.ReadAll(resp.Body)
+		if err == nil && len(body) > 0 {
+			// Try to parse as JSON to verify it's a valid token response
+			var tokenData map[string]interface{}
+			if json.Unmarshal(body, &tokenData) == nil {
+				if _, ok := tokenData["access_token"]; ok {
+					gologger.Info().Msgf("Discovered GCP provider (GCE/GKE instance with service account)\n")
+					// Return empty service account key - GCP provider will use ADC (Application Default Credentials)
+					// which automatically uses metadata service
+					return schema.OptionBlock{
+						"provider":                "gcp",
+						"id":                      "self-discovery",
+						"gcp_service_account_key": "",
+					}
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
 // discoverAzure attempts to discover Azure credentials
 func (sd *SelfDiscovery) discoverAzure() schema.OptionBlock {
-	// Check for Azure credentials in environment
+	// Priority 1: Check Azure Managed Identity (MSI)
+	if config := sd.tryAzureManagedIdentity(); config != nil {
+		return config
+	}
+
+	// Priority 2: Check for Azure credentials in environment
 	clientID := os.Getenv("AZURE_CLIENT_ID")
 	clientSecret := os.Getenv("AZURE_CLIENT_SECRET")
 	tenantID := os.Getenv("AZURE_TENANT_ID")
@@ -223,7 +392,7 @@ func (sd *SelfDiscovery) discoverAzure() schema.OptionBlock {
 		}
 	}
 
-	// Check if Azure CLI is configured and available
+	// Priority 3: Check if Azure CLI is configured and available
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
 		return nil
@@ -245,6 +414,108 @@ func (sd *SelfDiscovery) discoverAzure() schema.OptionBlock {
 
 		if sd.options.Verbose {
 			gologger.Verbose().Msgf("Azure CLI configuration found, but AZURE_SUBSCRIPTION_ID not set\n")
+		}
+	}
+
+	return nil
+}
+
+// tryAzureManagedIdentity attempts to get credentials from Azure Managed Identity
+func (sd *SelfDiscovery) tryAzureManagedIdentity() schema.OptionBlock {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	client := &http.Client{Timeout: 2 * time.Second}
+
+	// Check for App Service / Azure Functions MSI endpoint (newer method)
+	identityEndpoint := os.Getenv("IDENTITY_ENDPOINT")
+	identityHeader := os.Getenv("IDENTITY_HEADER")
+
+	if identityEndpoint != "" && identityHeader != "" {
+		// App Service / Azure Functions
+		req, err := http.NewRequestWithContext(ctx, "GET", identityEndpoint+"?api-version=2019-08-01&resource=https://management.azure.com/", nil)
+		if err == nil {
+			req.Header.Set("X-IDENTITY-HEADER", identityHeader)
+			resp, err := client.Do(req)
+			if err == nil {
+				defer resp.Body.Close()
+				if resp.StatusCode == 200 {
+					gologger.Info().Msgf("Discovered Azure provider (App Service/Functions with Managed Identity)\n")
+					// Get subscription ID from environment if available
+					subscriptionID := os.Getenv("AZURE_SUBSCRIPTION_ID")
+					config := schema.OptionBlock{
+						"provider": "azure",
+						"id":       "self-discovery",
+					}
+					if subscriptionID != "" {
+						config["subscription_id"] = subscriptionID
+					}
+					// Azure provider will use DefaultAzureCredential which includes managed identity
+					return config
+				}
+			}
+		}
+	}
+
+	// Check for older MSI endpoint (VM, Container Instances, etc.)
+	msiEndpoint := os.Getenv("MSI_ENDPOINT")
+	msiSecret := os.Getenv("MSI_SECRET")
+
+	if msiEndpoint != "" && msiSecret != "" {
+		req, err := http.NewRequestWithContext(ctx, "GET", msiEndpoint+"?api-version=2017-09-01&resource=https://management.azure.com/", nil)
+		if err == nil {
+			req.Header.Set("Secret", msiSecret)
+			resp, err := client.Do(req)
+			if err == nil {
+				defer resp.Body.Close()
+				if resp.StatusCode == 200 {
+					gologger.Info().Msgf("Discovered Azure provider (Container Instance with Managed Identity)\n")
+					subscriptionID := os.Getenv("AZURE_SUBSCRIPTION_ID")
+					config := schema.OptionBlock{
+						"provider": "azure",
+						"id":       "self-discovery",
+					}
+					if subscriptionID != "" {
+						config["subscription_id"] = subscriptionID
+					}
+					return config
+				}
+			}
+		}
+	}
+
+	// Try standard Azure VM IMDS endpoint
+	req, err := http.NewRequestWithContext(ctx, "GET", "http://169.254.169.254/metadata/identity/oauth2/token?api-version=2018-02-01&resource=https://management.azure.com/", nil)
+	if err != nil {
+		return nil
+	}
+	req.Header.Set("Metadata", "true")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == 200 {
+		body, err := io.ReadAll(resp.Body)
+		if err == nil && len(body) > 0 {
+			// Verify it's a valid token response
+			var tokenData map[string]interface{}
+			if json.Unmarshal(body, &tokenData) == nil {
+				if _, ok := tokenData["access_token"]; ok {
+					gologger.Info().Msgf("Discovered Azure provider (VM/AKS with Managed Identity)\n")
+					subscriptionID := os.Getenv("AZURE_SUBSCRIPTION_ID")
+					config := schema.OptionBlock{
+						"provider": "azure",
+						"id":       "self-discovery",
+					}
+					if subscriptionID != "" {
+						config["subscription_id"] = subscriptionID
+					}
+					return config
+				}
+			}
 		}
 	}
 

--- a/internal/runner/selfdiscovery.go
+++ b/internal/runner/selfdiscovery.go
@@ -1,0 +1,252 @@
+package runner
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/projectdiscovery/cloudlist/pkg/schema"
+	"github.com/projectdiscovery/gologger"
+	fileutil "github.com/projectdiscovery/utils/file"
+)
+
+// SelfDiscovery handles auto-discovery of cloud providers from environment variables
+type SelfDiscovery struct {
+	options *Options
+}
+
+// NewSelfDiscovery creates a new self-discovery instance
+func NewSelfDiscovery(options *Options) *SelfDiscovery {
+	return &SelfDiscovery{options: options}
+}
+
+// DiscoverProviders attempts to auto-discover available providers from environment
+func (sd *SelfDiscovery) DiscoverProviders() schema.Options {
+	discoveredConfig := schema.Options{}
+
+	// Check which providers to discover
+	providersToCheck := sd.getProvidersToCheck()
+
+	for _, provider := range providersToCheck {
+		switch provider {
+		case "kubernetes":
+			if config := sd.discoverKubernetes(); config != nil {
+				discoveredConfig = append(discoveredConfig, config)
+			}
+		case "aws":
+			if config := sd.discoverAWS(); config != nil {
+				discoveredConfig = append(discoveredConfig, config)
+			}
+		case "gcp":
+			if config := sd.discoverGCP(); config != nil {
+				discoveredConfig = append(discoveredConfig, config)
+			}
+		case "azure":
+			if config := sd.discoverAzure(); config != nil {
+				discoveredConfig = append(discoveredConfig, config)
+			}
+		}
+	}
+
+	return discoveredConfig
+}
+
+// getProvidersToCheck returns the list of providers to check
+func (sd *SelfDiscovery) getProvidersToCheck() []string {
+	// If specific providers are requested, use those
+	if len(sd.options.Providers) > 0 {
+		return sd.options.Providers
+	}
+
+	// Otherwise, check all supported providers
+	return []string{"kubernetes", "aws", "gcp", "azure"}
+}
+
+// discoverKubernetes attempts to discover Kubernetes configuration
+func (sd *SelfDiscovery) discoverKubernetes() schema.OptionBlock {
+	var kubeconfigPath string
+
+	// Check KUBECONFIG environment variable first
+	if envKubeconfig := os.Getenv("KUBECONFIG"); envKubeconfig != "" {
+		kubeconfigPath = envKubeconfig
+		// KUBECONFIG can contain multiple paths separated by colon
+		// Use the first one
+		if strings.Contains(kubeconfigPath, ":") {
+			kubeconfigPath = strings.Split(kubeconfigPath, ":")[0]
+		}
+	} else {
+		// Fallback to default kubeconfig location
+		homeDir, err := os.UserHomeDir()
+		if err != nil {
+			if sd.options.Verbose {
+				gologger.Verbose().Msgf("Could not get user home directory: %s\n", err)
+			}
+			return nil
+		}
+		kubeconfigPath = filepath.Join(homeDir, ".kube", "config")
+	}
+
+	// check if /var/run/secrets/kubernetes.io/serviceaccount/token exists
+	if fileutil.FileExists("/var/run/secrets/kubernetes.io/serviceaccount/token") {
+		gologger.Info().Msgf("Discovered Kubernetes provider (in-cluster mode)\n")
+		return schema.OptionBlock{
+			"provider":       "kubernetes",
+			"id":             "self-discovery",
+			"incluster_mode": "true",
+		}
+	}
+
+	// Check if kubeconfig file exists
+	if !fileutil.FileExists(kubeconfigPath) {
+		if sd.options.Verbose {
+			gologger.Verbose().Msgf("Kubeconfig file not found at: %s\n", kubeconfigPath)
+		}
+		return nil
+	}
+
+	gologger.Info().Msgf("Discovered Kubernetes provider (kubeconfig: %s)\n", kubeconfigPath)
+
+	return schema.OptionBlock{
+		"provider":        "kubernetes",
+		"id":              "self-discovery",
+		"kubeconfig_file": kubeconfigPath,
+	}
+}
+
+// discoverAWS attempts to discover AWS credentials
+func (sd *SelfDiscovery) discoverAWS() schema.OptionBlock {
+	// Check for AWS credentials in environment
+	accessKey := os.Getenv("AWS_ACCESS_KEY_ID")
+	secretKey := os.Getenv("AWS_SECRET_ACCESS_KEY")
+	sessionToken := os.Getenv("AWS_SESSION_TOKEN")
+
+	// Also check for AWS profile
+	profile := os.Getenv("AWS_PROFILE")
+
+	// If we have access key and secret key, we can proceed
+	if accessKey != "" && secretKey != "" {
+		gologger.Info().Msgf("Discovered AWS provider (from environment variables)\n")
+
+		config := schema.OptionBlock{
+			"provider":       "aws",
+			"id":             "self-discovery",
+			"aws_access_key": accessKey,
+			"aws_secret_key": secretKey,
+		}
+
+		if sessionToken != "" {
+			config["aws_session_token"] = sessionToken
+		}
+
+		return config
+	}
+
+	// Check for AWS credentials file
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return nil
+	}
+
+	awsCredsPath := filepath.Join(homeDir, ".aws", "credentials")
+	awsConfigPath := filepath.Join(homeDir, ".aws", "config")
+
+	if fileutil.FileExists(awsCredsPath) || fileutil.FileExists(awsConfigPath) {
+		if sd.options.Verbose {
+			gologger.Verbose().Msgf("AWS credentials file found, but direct env variables not set\n")
+			gologger.Verbose().Msgf("Please set AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY or use provider config\n")
+			if profile != "" {
+				gologger.Verbose().Msgf("AWS_PROFILE detected: %s (not yet supported in self-discovery)\n", profile)
+			}
+		}
+	}
+
+	return nil
+}
+
+// discoverGCP attempts to discover GCP credentials
+func (sd *SelfDiscovery) discoverGCP() schema.OptionBlock {
+	// Check for GCP application credentials
+	credsPath := os.Getenv("GOOGLE_APPLICATION_CREDENTIALS")
+
+	if credsPath == "" {
+		// Check for default location
+		homeDir, err := os.UserHomeDir()
+		if err != nil {
+			return nil
+		}
+		credsPath = filepath.Join(homeDir, ".config", "gcloud", "application_default_credentials.json")
+	}
+
+	if !fileutil.FileExists(credsPath) {
+		if sd.options.Verbose {
+			gologger.Verbose().Msgf("GCP credentials not found at: %s\n", credsPath)
+		}
+		return nil
+	}
+
+	// Read the service account key file
+	keyData, err := os.ReadFile(credsPath)
+	if err != nil {
+		if sd.options.Verbose {
+			gologger.Verbose().Msgf("Could not read GCP credentials file: %s\n", err)
+		}
+		return nil
+	}
+
+	gologger.Info().Msgf("Discovered GCP provider (credentials: %s)\n", credsPath)
+
+	return schema.OptionBlock{
+		"provider":                "gcp",
+		"id":                      "self-discovery",
+		"gcp_service_account_key": string(keyData),
+	}
+}
+
+// discoverAzure attempts to discover Azure credentials
+func (sd *SelfDiscovery) discoverAzure() schema.OptionBlock {
+	// Check for Azure credentials in environment
+	clientID := os.Getenv("AZURE_CLIENT_ID")
+	clientSecret := os.Getenv("AZURE_CLIENT_SECRET")
+	tenantID := os.Getenv("AZURE_TENANT_ID")
+	subscriptionID := os.Getenv("AZURE_SUBSCRIPTION_ID")
+
+	if clientID != "" && clientSecret != "" && tenantID != "" && subscriptionID != "" {
+		gologger.Info().Msgf("Discovered Azure provider (from environment variables)\n")
+
+		return schema.OptionBlock{
+			"provider":        "azure",
+			"id":              "self-discovery",
+			"client_id":       clientID,
+			"client_secret":   clientSecret,
+			"tenant_id":       tenantID,
+			"subscription_id": subscriptionID,
+		}
+	}
+
+	// Check if Azure CLI is configured and available
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return nil
+	}
+
+	azureConfigPath := filepath.Join(homeDir, ".azure")
+	if fileutil.FolderExists(azureConfigPath) {
+		// Check if we have at least subscription ID
+		if subscriptionID != "" {
+			gologger.Info().Msgf("Discovered Azure provider (using Azure CLI auth)\n")
+
+			return schema.OptionBlock{
+				"provider":        "azure",
+				"id":              "self-discovery",
+				"subscription_id": subscriptionID,
+				"use_cli_auth":    "true",
+			}
+		}
+
+		if sd.options.Verbose {
+			gologger.Verbose().Msgf("Azure CLI configuration found, but AZURE_SUBSCRIPTION_ID not set\n")
+		}
+	}
+
+	return nil
+}

--- a/pkg/inventory/inventory.go
+++ b/pkg/inventory/inventory.go
@@ -25,6 +25,7 @@ import (
 	"github.com/projectdiscovery/cloudlist/pkg/providers/terraform"
 	"github.com/projectdiscovery/cloudlist/pkg/providers/vercel"
 	"github.com/projectdiscovery/cloudlist/pkg/schema"
+	"github.com/projectdiscovery/gologger"
 	mapsutil "github.com/projectdiscovery/utils/maps"
 )
 
@@ -35,7 +36,15 @@ type Inventory struct {
 
 // New creates a new inventory of providers
 func New(optionBlocks schema.Options) (*Inventory, error) {
+	return NewWithOptions(optionBlocks, false, false)
+}
+
+// NewWithOptions creates a new inventory of providers with options
+// gracefulFailure: if true, skip providers that fail to initialize instead of returning error
+// verbose: if true, show errors for failed providers (only used when gracefulFailure is true)
+func NewWithOptions(optionBlocks schema.Options, gracefulFailure bool, verbose bool) (*Inventory, error) {
 	inventory := &Inventory{}
+	var failedProviders []string
 
 	for _, block := range optionBlocks {
 		value, ok := block.GetMetadata("provider")
@@ -44,10 +53,28 @@ func New(optionBlocks schema.Options) (*Inventory, error) {
 		}
 		provider, err := nameToProvider(value, block)
 		if err != nil {
+			if gracefulFailure {
+				// In graceful failure mode, skip this provider and continue
+				failedProviders = append(failedProviders, value)
+				if verbose {
+					gologger.Verbose().Msgf("Skipping provider %s: %s\n", value, err)
+				} else {
+					gologger.Debug().Msgf("Skipping provider %s: %s\n", value, err)
+				}
+				continue
+			}
 			return nil, fmt.Errorf("could not create provider %s: %s", value, err)
 		}
 		inventory.Providers = append(inventory.Providers, provider)
 	}
+
+	// If graceful failure is enabled and we have some successful providers, log summary
+	if gracefulFailure && len(failedProviders) > 0 {
+		if verbose {
+			gologger.Warning().Msgf("Failed to initialize %d provider(s): %v\n", len(failedProviders), failedProviders)
+		}
+	}
+
 	return inventory, nil
 }
 

--- a/pkg/providers/aws/aws.go
+++ b/pkg/providers/aws/aws.go
@@ -46,7 +46,7 @@ type ProviderOptions struct {
 func (p *ProviderOptions) ParseOptionBlock(block schema.OptionBlock) error {
 	p.Id, _ = block.GetMetadata("id")
 
-	// Check if using IMDS or ECS task role (for self-discovery mode)
+	// Check if using IMDS or ECS task role (for auto-discovery mode)
 	useIMDS, _ := block.GetMetadata("use_imds")
 	useECSTaskRole, _ := block.GetMetadata("use_ecs_task_role")
 

--- a/pkg/providers/aws/aws.go
+++ b/pkg/providers/aws/aws.go
@@ -45,17 +45,30 @@ type ProviderOptions struct {
 
 func (p *ProviderOptions) ParseOptionBlock(block schema.OptionBlock) error {
 	p.Id, _ = block.GetMetadata("id")
-	accessKey, ok := block.GetMetadata(apiAccessKey)
-	if !ok {
-		return &schema.ErrNoSuchKey{Name: apiAccessKey}
+
+	// Check if using IMDS or ECS task role (for self-discovery mode)
+	useIMDS, _ := block.GetMetadata("use_imds")
+	useECSTaskRole, _ := block.GetMetadata("use_ecs_task_role")
+
+	// If using metadata service, credentials are optional
+	if useIMDS != "true" && useECSTaskRole != "true" {
+		accessKey, ok := block.GetMetadata(apiAccessKey)
+		if !ok {
+			return &schema.ErrNoSuchKey{Name: apiAccessKey}
+		}
+		accessToken, ok := block.GetMetadata(apiSecretKey)
+		if !ok {
+			return &schema.ErrNoSuchKey{Name: apiSecretKey}
+		}
+		p.AccessKey = accessKey
+		p.SecretKey = accessToken
+	} else {
+		// For IMDS/ECS task role, credentials are optional
+		p.AccessKey, _ = block.GetMetadata(apiAccessKey)
+		p.SecretKey, _ = block.GetMetadata(apiSecretKey)
 	}
-	accessToken, ok := block.GetMetadata(apiSecretKey)
-	if !ok {
-		return &schema.ErrNoSuchKey{Name: apiSecretKey}
-	}
+
 	p.Token, _ = block.GetMetadata(sessionToken)
-	p.AccessKey = accessKey
-	p.SecretKey = accessToken
 
 	if assumeRoleArn, ok := block.GetMetadata(assumeRoleArn); ok {
 		p.AssumeRoleArn = assumeRoleArn
@@ -131,7 +144,12 @@ func New(block schema.OptionBlock) (*Provider, error) {
 	provider := &Provider{options: options}
 	config := aws.NewConfig()
 	config.WithRegion("us-east-1")
-	config.WithCredentials(credentials.NewStaticCredentials(options.AccessKey, options.SecretKey, options.Token))
+
+	// Only set static credentials if we have them
+	// Otherwise, SDK will use default credential chain (IMDS, ECS task role, env vars, etc.)
+	if options.AccessKey != "" && options.SecretKey != "" {
+		config.WithCredentials(credentials.NewStaticCredentials(options.AccessKey, options.SecretKey, options.Token))
+	}
 
 	var sess *session.Session
 	var err error

--- a/pkg/providers/k8s/kubernetes.go
+++ b/pkg/providers/k8s/kubernetes.go
@@ -28,6 +28,7 @@ const (
 	kubeconfig_file   = "kubeconfig_file"
 	encodedKubeConfig = "kubeconfig_encoded"
 	providerName      = "kubernetes"
+	inclusterMode     = "incluster_mode"
 )
 
 func New(options schema.OptionBlock) (*Provider, error) {
@@ -35,6 +36,7 @@ func New(options schema.OptionBlock) (*Provider, error) {
 
 	configFile, ok := options.GetMetadata(kubeconfig_file)
 	configEncoded, strOk := options.GetMetadata(encodedKubeConfig)
+	_, inclusterModeOk := options.GetMetadata(inclusterMode)
 
 	if !ok && !strOk {
 		return nil, errkit.New("no kubeconfig_file or kubeconfig_encoded  provided")
@@ -51,6 +53,11 @@ func New(options schema.OptionBlock) (*Provider, error) {
 		kubeConfig, err = buildConfigFromStr(context, decodedConfig)
 		if err != nil {
 			return nil, errkit.Wrap(err, "could not build kubeconfig")
+		}
+	} else if inclusterModeOk {
+		kubeConfig, err = rest.InClusterConfig()
+		if err != nil {
+			return nil, errkit.Wrap(err, "could not get in-cluster config")
 		}
 	} else {
 		kubeConfig, err = buildConfigWithContext(context, configFile)

--- a/pkg/providers/k8s/kubernetes.go
+++ b/pkg/providers/k8s/kubernetes.go
@@ -38,8 +38,8 @@ func New(options schema.OptionBlock) (*Provider, error) {
 	configEncoded, strOk := options.GetMetadata(encodedKubeConfig)
 	_, inclusterModeOk := options.GetMetadata(inclusterMode)
 
-	if !ok && !strOk {
-		return nil, errkit.New("no kubeconfig_file or kubeconfig_encoded  provided")
+	if !ok && !strOk && !inclusterModeOk {
+		return nil, errkit.New("no kubeconfig_file or kubeconfig_encoded or incluster_mode provided")
 	}
 	context, _ := options.GetMetadata("context")
 


### PR DESCRIPTION
This PR adds support for auto discovery. With the -ad flag, you no longer need to provide a provider config manually—it automatically detects environment variables or IAM attachments on VMs/pods and uses the appropriate authentication method.
Testing checklist:

- [x] aws
- [x]  gcp
- [x] k8s
- [ ] azure

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added automatic cloud provider discovery from environment configurations, supporting Kubernetes, AWS, GCP, and Azure detection.
  * Introduced `--auto-discovery` flag to enable provider auto-detection without requiring explicit configuration files.

* **Bug Fixes**
  * Added defensive nil check to prevent crashes when runner initialization fails.

* **Improvements**
  * Enhanced credential chain handling for AWS provider to automatically use IMDS and ECS task role credentials when available.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->