### PR TITLE
fix Dockerfile Go version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Base
-FROM golang:1.21.1-alpine AS builder
+FROM golang:1.24-alpine AS builder
 RUN apk add --no-cache build-base
 WORKDIR /app
 COPY . /app
@@ -7,7 +7,7 @@ RUN go mod download
 RUN go build ./cmd/cloudlist
 
 # Release
-FROM alpine:3.18.4
+FROM alpine:3.23
 RUN apk -U upgrade --no-cache \
     && apk add --no-cache bind-tools ca-certificates
 COPY --from=builder /app/cloudlist /usr/local/bin/

--- a/internal/runner/banner.go
+++ b/internal/runner/banner.go
@@ -13,7 +13,7 @@ const banner = `
 `
 
 // version is the current version of cloudlist
-const version = `1.3.0`
+const version = `1.3.1`
 
 // showBanner is used to show the banner to the user
 func showBanner() {


### PR DESCRIPTION
fixes #724 - update Go version from 1.21.1 to 1.24 to match go.mod requirement

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated container base images to newer Go and Alpine versions for improved compatibility, security, and performance.
  * Configured the container to start the application automatically by defining a default startup command.
  * Bumped the displayed application version to 1.3.1 (updated banner/version shown to users).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->