### PR TITLE
feat(cloudflare): add `record_content` to DNS metadata

### DIFF
--- a/pkg/providers/cloudflare/dns.go
+++ b/pkg/providers/cloudflare/dns.go
@@ -94,6 +94,7 @@ func (d *dnsProvider) getDNSRecordMetadata(record *cloudflare.DNSRecord, zone *c
 	metadata["record_id"] = record.ID
 	metadata["record_type"] = record.Type
 	metadata["record_name"] = record.Name
+	metadata["record_content"] = record.Content
 
 	if record.TTL > 0 {
 		metadata["ttl"] = fmt.Sprintf("%d", record.TTL)


### PR DESCRIPTION
Include record content for DNS/CNAME correlation.

Closes #727 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced DNS record metadata to include content details when extended metadata is enabled, providing richer information about DNS records for improved visibility and management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->