### PR TITLE
fix(cloudflare): honor `extended_metadata` with `api_token`

### DIFF
--- a/pkg/providers/cloudflare/cloudflare.go
+++ b/pkg/providers/cloudflare/cloudflare.go
@@ -42,6 +42,12 @@ func New(options schema.OptionBlock) (*Provider, error) {
 		}
 	}
 
+	// Parse extended metadata option
+	extendedMetadata := false
+	if extMetadata, ok := options.GetMetadata("extended_metadata"); ok {
+		extendedMetadata = extMetadata == "true"
+	}
+
 	apiToken, ok := options.GetMetadata(apiToken)
 	if ok {
 		// Construct a new API object with scoped api token
@@ -49,7 +55,7 @@ func New(options schema.OptionBlock) (*Provider, error) {
 		if err != nil {
 			return nil, err
 		}
-		return &Provider{id: id, client: api, services: services}, nil
+		return &Provider{id: id, client: api, services: services, extendedMetadata: extendedMetadata}, nil
 	}
 
 	accessKey, ok := options.GetMetadata(apiAccessKey)
@@ -65,12 +71,6 @@ func New(options schema.OptionBlock) (*Provider, error) {
 	api, err := cloudflare.New(accessKey, apiEmail)
 	if err != nil {
 		return nil, err
-	}
-
-	// Parse extended metadata option
-	extendedMetadata := false
-	if extMetadata, ok := options.GetMetadata("extended_metadata"); ok {
-		extendedMetadata = extMetadata == "true"
 	}
 
 	return &Provider{id: id, client: api, services: services, extendedMetadata: extendedMetadata}, nil


### PR DESCRIPTION
Keep extended metadata enabled for scoped-token
auth.

Closes #728 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added extended_metadata configuration option for Cloudflare provider to access enhanced metadata when needed.

* **Bug Fixes**
  * Fixed metadata option handling consistency across API token and legacy authentication methods.

* **Refactor**
  * Removed duplicate parsing code to streamline configuration processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->