### PR TITLE
feature(aws): add org discovery and account blacklist support

### DIFF
--- a/pkg/providers/aws/aws.go
+++ b/pkg/providers/aws/aws.go
@@ -215,7 +215,7 @@ func New(block schema.OptionBlock) (*Provider, error) {
 		if options.AssumeRoleName == "" {
 			return nil, errors.New("assume_role_name is required when using org_discovery_role_arn")
 		}
-		discovered, err := provider.discoverOrgAccounts(sess, config)
+		discovered, err := provider.discoverOrgAccounts(context.Background(), sess, config)
 		if err != nil {
 			gologger.Warning().Msgf("Failed to discover org accounts: %s", err)
 		} else {
@@ -314,7 +314,7 @@ func createAssumedRoleSession(options *ProviderOptions, sess *session.Session, c
 
 // discoverOrgAccounts assumes the org discovery role and lists all active
 // accounts in the AWS Organization via organizations:ListAccounts.
-func (p *Provider) discoverOrgAccounts(sess *session.Session, config *aws.Config) ([]string, error) {
+func (p *Provider) discoverOrgAccounts(ctx context.Context, sess *session.Session, config *aws.Config) ([]string, error) {
 	stsClient := sts.New(sess)
 
 	roleInput := &sts.AssumeRoleInput{
@@ -325,7 +325,7 @@ func (p *Provider) discoverOrgAccounts(sess *session.Session, config *aws.Config
 		roleInput.ExternalId = aws.String(p.options.ExternalId)
 	}
 
-	assumeOut, err := stsClient.AssumeRole(roleInput)
+	assumeOut, err := stsClient.AssumeRoleWithContext(ctx, roleInput)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not assume org discovery role")
 	}
@@ -345,7 +345,7 @@ func (p *Provider) discoverOrgAccounts(sess *session.Session, config *aws.Config
 	orgClient := organizations.New(orgSess)
 	var accountIDs []string
 
-	err = orgClient.ListAccountsPages(&organizations.ListAccountsInput{}, func(page *organizations.ListAccountsOutput, lastPage bool) bool {
+	err = orgClient.ListAccountsPagesWithContext(ctx, &organizations.ListAccountsInput{}, func(page *organizations.ListAccountsOutput, lastPage bool) bool {
 		for _, acct := range page.Accounts {
 			if acct.Status != nil && *acct.Status == "ACTIVE" && acct.Id != nil {
 				accountIDs = append(accountIDs, *acct.Id)
@@ -514,7 +514,7 @@ func (p *Provider) Resources(ctx context.Context) (*schema.Resources, error) {
 func (p *Provider) Verify(ctx context.Context) error {
 	// Verify org discovery role can assume and list accounts
 	if p.options.OrgDiscoveryRoleArn != "" {
-		if _, err := p.discoverOrgAccounts(p.session, p.session.Config); err != nil {
+		if _, err := p.discoverOrgAccounts(ctx, p.session, p.session.Config); err != nil {
 			return errors.Wrap(err, "org discovery verification failed")
 		}
 	}

--- a/pkg/providers/aws/aws.go
+++ b/pkg/providers/aws/aws.go
@@ -104,10 +104,10 @@ func (p *ProviderOptions) ParseOptionBlock(block schema.OptionBlock) error {
 	}
 
 	if accountIds, ok := block.GetMetadata(accountIds); ok {
-		p.AccountIds = sliceutil.Dedupe(strings.Split(strings.ReplaceAll(accountIds, " ", ""), ","))
+		p.AccountIds = sliceutil.Dedupe(strings.Split(accountIds, ","))
 	}
 	if eids, ok := block.GetMetadata(excludeAccountIds); ok {
-		p.ExcludeAccountIds = strings.Split(strings.ReplaceAll(eids, " ", ""), ",")
+		p.ExcludeAccountIds = sliceutil.Dedupe(strings.Split(eids, ","))
 	}
 	return nil
 }

--- a/pkg/providers/aws/aws.go
+++ b/pkg/providers/aws/aws.go
@@ -217,10 +217,9 @@ func New(block schema.OptionBlock) (*Provider, error) {
 		}
 		discovered, err := provider.discoverOrgAccounts(context.Background(), sess, config)
 		if err != nil {
-			gologger.Warning().Msgf("Failed to discover org accounts: %s", err)
-		} else {
-			gologger.Info().Msgf("Discovered %d accounts from AWS Organizations", len(discovered))
+			return nil, errors.Wrap(err, "failed to discover org accounts")
 		}
+		gologger.Info().Msgf("Discovered %d accounts from AWS Organizations", len(discovered))
 		options.AccountIds = sliceutil.Dedupe(append(options.AccountIds, discovered...))
 	}
 

--- a/pkg/providers/aws/aws.go
+++ b/pkg/providers/aws/aws.go
@@ -19,6 +19,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/elbv2"
 	"github.com/aws/aws-sdk-go/service/lambda"
 	"github.com/aws/aws-sdk-go/service/lightsail"
+	"github.com/aws/aws-sdk-go/service/organizations"
 	"github.com/aws/aws-sdk-go/service/route53"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/sts"
@@ -38,7 +39,9 @@ type ProviderOptions struct {
 	AssumeRoleSessionName string
 	ExternalId            string
 	AssumeRoleName        string
+	OrgDiscoveryRoleArn   string
 	AccountIds            []string
+	ExcludeAccountIds     []string
 	Services              schema.ServiceMap
 	ExtendedMetadata      bool
 }
@@ -72,6 +75,10 @@ func (p *ProviderOptions) ParseOptionBlock(block schema.OptionBlock) error {
 		p.AssumeRoleName = assumeRoleName
 	}
 
+	if orgRoleArn, ok := block.GetMetadata(orgDiscoveryRoleArn); ok {
+		p.OrgDiscoveryRoleArn = orgRoleArn
+	}
+
 	supportedServicesMap := make(map[string]struct{})
 	for _, s := range Services {
 		supportedServicesMap[s] = struct{}{}
@@ -97,7 +104,10 @@ func (p *ProviderOptions) ParseOptionBlock(block schema.OptionBlock) error {
 	}
 
 	if accountIds, ok := block.GetMetadata(accountIds); ok {
-		p.AccountIds = sliceutil.Dedupe(strings.Split(accountIds, ","))
+		p.AccountIds = sliceutil.Dedupe(strings.Split(strings.ReplaceAll(accountIds, " ", ""), ","))
+	}
+	if eids, ok := block.GetMetadata(excludeAccountIds); ok {
+		p.ExcludeAccountIds = strings.Split(strings.ReplaceAll(eids, " ", ""), ",")
 	}
 	return nil
 }
@@ -126,6 +136,20 @@ func New(block schema.OptionBlock) (*Provider, error) {
 	options := &ProviderOptions{}
 	if err := options.ParseOptionBlock(block); err != nil {
 		return nil, err
+	}
+
+	// assume_role_arn replaces the session entirely, so it cannot be combined
+	// with multi-account fields that require the raw credentials session
+	if options.AssumeRoleArn != "" {
+		if options.AssumeRoleName != "" {
+			return nil, errors.New("assume_role_arn and assume_role_name cannot be used together")
+		}
+		if options.OrgDiscoveryRoleArn != "" {
+			return nil, errors.New("assume_role_arn and org_discovery_role_arn cannot be used together")
+		}
+		if len(options.AccountIds) > 0 {
+			return nil, errors.New("assume_role_arn and account_ids cannot be used together")
+		}
 	}
 
 	provider := &Provider{options: options}
@@ -184,6 +208,33 @@ func New(block schema.OptionBlock) (*Provider, error) {
 	}
 
 	provider.session = sess
+
+	// Discover accounts from AWS Organizations if configured
+	if options.OrgDiscoveryRoleArn != "" {
+		if options.AssumeRoleName == "" {
+			return nil, errors.New("assume_role_name is required when using org_discovery_role_arn")
+		}
+		discovered, err := provider.discoverOrgAccounts(sess, config)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to discover org accounts")
+		}
+		options.AccountIds = sliceutil.Dedupe(append(options.AccountIds, discovered...))
+	}
+
+	// Apply exclude filter to account_ids (works with both manual and discovered accounts)
+	if len(options.ExcludeAccountIds) > 0 && len(options.AccountIds) > 0 {
+		excludeSet := make(map[string]struct{})
+		for _, id := range options.ExcludeAccountIds {
+			excludeSet[id] = struct{}{}
+		}
+		filtered := make([]string, 0, len(options.AccountIds))
+		for _, id := range options.AccountIds {
+			if _, excluded := excludeSet[id]; !excluded {
+				filtered = append(filtered, id)
+			}
+		}
+		options.AccountIds = filtered
+	}
 
 	// Handle DescribeRegions call with fallback for assume_role_name case
 	var regions *ec2.DescribeRegionsOutput
@@ -254,6 +305,54 @@ func createAssumedRoleSession(options *ProviderOptions, sess *session.Session, c
 	return tempSession, nil
 }
 
+// discoverOrgAccounts assumes the org discovery role and lists all active
+// accounts in the AWS Organization via organizations:ListAccounts.
+func (p *Provider) discoverOrgAccounts(sess *session.Session, config *aws.Config) ([]string, error) {
+	stsClient := sts.New(sess)
+
+	roleInput := &sts.AssumeRoleInput{
+		RoleArn:        aws.String(p.options.OrgDiscoveryRoleArn),
+		RoleSessionName: aws.String("cloudlist-org-discovery"),
+	}
+	if p.options.ExternalId != "" {
+		roleInput.ExternalId = aws.String(p.options.ExternalId)
+	}
+
+	assumeOut, err := stsClient.AssumeRole(roleInput)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not assume org discovery role")
+	}
+
+	orgSess, err := session.NewSession(&aws.Config{
+		Region: config.Region,
+		Credentials: credentials.NewStaticCredentials(
+			*assumeOut.Credentials.AccessKeyId,
+			*assumeOut.Credentials.SecretAccessKey,
+			*assumeOut.Credentials.SessionToken,
+		),
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "could not create org discovery session")
+	}
+
+	orgClient := organizations.New(orgSess)
+	var accountIDs []string
+
+	err = orgClient.ListAccountsPages(&organizations.ListAccountsInput{}, func(page *organizations.ListAccountsOutput, lastPage bool) bool {
+		for _, acct := range page.Accounts {
+			if acct.Status != nil && *acct.Status == "ACTIVE" && acct.Id != nil {
+				accountIDs = append(accountIDs, *acct.Id)
+			}
+		}
+		return true
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "could not list org accounts")
+	}
+
+	return accountIDs, nil
+}
+
 func (p *Provider) initServices(sess *session.Session) {
 	services := p.options.Services
 
@@ -302,6 +401,8 @@ const assumeRoleArn = "assume_role_arn"
 const externalId = "external_id"
 const assumeRoleSessionName = "assume_role_session_name"
 const accountIds = "account_ids"
+const excludeAccountIds = "exclude_account_ids"
+const orgDiscoveryRoleArn = "org_discovery_role_arn"
 
 // Name returns the name of the provider
 func (p *Provider) Name() string {

--- a/pkg/providers/aws/aws.go
+++ b/pkg/providers/aws/aws.go
@@ -217,9 +217,10 @@ func New(block schema.OptionBlock) (*Provider, error) {
 		}
 		discovered, err := provider.discoverOrgAccounts(sess, config)
 		if err != nil {
-			return nil, errors.Wrap(err, "failed to discover org accounts")
+			gologger.Warning().Msgf("Failed to discover org accounts: %s", err)
+		} else {
+			gologger.Info().Msgf("Discovered %d accounts from AWS Organizations", len(discovered))
 		}
-		gologger.Info().Msgf("Discovered %d accounts from AWS Organizations", len(discovered))
 		options.AccountIds = sliceutil.Dedupe(append(options.AccountIds, discovered...))
 	}
 
@@ -317,7 +318,7 @@ func (p *Provider) discoverOrgAccounts(sess *session.Session, config *aws.Config
 	stsClient := sts.New(sess)
 
 	roleInput := &sts.AssumeRoleInput{
-		RoleArn:        aws.String(p.options.OrgDiscoveryRoleArn),
+		RoleArn:         aws.String(p.options.OrgDiscoveryRoleArn),
 		RoleSessionName: aws.String("cloudlist-org-discovery"),
 	}
 	if p.options.ExternalId != "" {
@@ -511,6 +512,13 @@ func (p *Provider) Resources(ctx context.Context) (*schema.Resources, error) {
 
 // Verify checks if the provider is valid using simple API calls
 func (p *Provider) Verify(ctx context.Context) error {
+	// Verify org discovery role can assume and list accounts
+	if p.options.OrgDiscoveryRoleArn != "" {
+		if _, err := p.discoverOrgAccounts(p.session, p.session.Config); err != nil {
+			return errors.Wrap(err, "org discovery verification failed")
+		}
+	}
+
 	err := p.verify()
 	if err == nil {
 		return nil
@@ -521,13 +529,8 @@ func (p *Provider) Verify(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
-
 		p.initServices(tempSession)
-		err = p.verify()
-		if err != nil {
-			return err
-		}
-		return nil
+		return p.verify()
 	}
 	return err
 }

--- a/pkg/providers/aws/aws.go
+++ b/pkg/providers/aws/aws.go
@@ -240,7 +240,7 @@ func New(block schema.OptionBlock) (*Provider, error) {
 	}
 
 	if len(options.AccountIds) > 0 && options.AssumeRoleName != "" {
-		gologger.Info().Msgf("Will assume role %s in %d accounts: %s", options.AssumeRoleName, len(options.AccountIds), strings.Join(options.AccountIds, ", "))
+		gologger.Info().Msgf("Will assume role %s in %d accounts", options.AssumeRoleName, len(options.AccountIds))
 	}
 
 	// Handle DescribeRegions call with fallback for assume_role_name case

--- a/pkg/providers/aws/aws.go
+++ b/pkg/providers/aws/aws.go
@@ -25,6 +25,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/sts"
 	"github.com/pkg/errors"
 	"github.com/projectdiscovery/cloudlist/pkg/schema"
+	"github.com/projectdiscovery/gologger"
 	sliceutil "github.com/projectdiscovery/utils/slice"
 )
 
@@ -218,6 +219,7 @@ func New(block schema.OptionBlock) (*Provider, error) {
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to discover org accounts")
 		}
+		gologger.Info().Msgf("Discovered %d accounts from AWS Organizations", len(discovered))
 		options.AccountIds = sliceutil.Dedupe(append(options.AccountIds, discovered...))
 	}
 
@@ -234,6 +236,10 @@ func New(block schema.OptionBlock) (*Provider, error) {
 			}
 		}
 		options.AccountIds = filtered
+	}
+
+	if len(options.AccountIds) > 0 && options.AssumeRoleName != "" {
+		gologger.Info().Msgf("Will assume role %s in %d accounts: %s", options.AssumeRoleName, len(options.AccountIds), strings.Join(options.AccountIds, ", "))
 	}
 
 	// Handle DescribeRegions call with fallback for assume_role_name case

--- a/pkg/providers/aws/aws.go
+++ b/pkg/providers/aws/aws.go
@@ -529,7 +529,11 @@ func (p *Provider) Verify(ctx context.Context) error {
 			return err
 		}
 		p.initServices(tempSession)
-		return p.verify()
+		err = p.verify()
+		if err != nil {
+			return err
+		}
+		return nil
 	}
 	return err
 }

--- a/pkg/schema/schema.go
+++ b/pkg/schema/schema.go
@@ -253,6 +253,12 @@ func (ob *OptionBlock) UnmarshalYAML(unmarshal func(interface{}) error) error {
 						} else {
 							strArr = append(strArr, fmt.Sprint(v))
 						}
+					case float64:
+						if key == "account_ids" || key == "exclude_account_ids" {
+							strArr = append(strArr, fmt.Sprintf("%012.0f", v))
+						} else {
+							strArr = append(strArr, fmt.Sprint(v))
+						}
 					default:
 						return fmt.Errorf("unsupported type %T in %s", v, key)
 					}

--- a/pkg/schema/schema.go
+++ b/pkg/schema/schema.go
@@ -240,7 +240,7 @@ func (ob *OptionBlock) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	// Convert raw map to OptionBlock and handle special cases
 	for key, value := range rawMap {
 		switch key {
-		case "account_ids", "urls", "services":
+		case "account_ids", "exclude_account_ids", "urls", "services":
 			if valueArr, ok := value.([]interface{}); ok {
 				var strArr []string
 				for _, v := range valueArr {
@@ -250,7 +250,7 @@ func (ob *OptionBlock) UnmarshalYAML(unmarshal func(interface{}) error) error {
 					case int:
 						strArr = append(strArr, fmt.Sprint(v))
 					default:
-						return fmt.Errorf("unsupported type %T in account_ids", v)
+						return fmt.Errorf("unsupported type %T in %s", v, key)
 					}
 				}
 				(*ob)[key] = strings.Join(strArr, ",")

--- a/pkg/schema/schema.go
+++ b/pkg/schema/schema.go
@@ -248,7 +248,11 @@ func (ob *OptionBlock) UnmarshalYAML(unmarshal func(interface{}) error) error {
 					case string:
 						strArr = append(strArr, v)
 					case int:
-						strArr = append(strArr, fmt.Sprint(v))
+						if key == "account_ids" || key == "exclude_account_ids" {
+							strArr = append(strArr, fmt.Sprintf("%012d", v))
+						} else {
+							strArr = append(strArr, fmt.Sprint(v))
+						}
 					default:
 						return fmt.Errorf("unsupported type %T in %s", v, key)
 					}

--- a/pkg/schema/schema_test.go
+++ b/pkg/schema/schema_test.go
@@ -24,3 +24,68 @@ func TestOptionBlockParsesProjectIDs(t *testing.T) {
 	require.True(t, ok)
 	require.Equal(t, "alpha,beta,alpha", value)
 }
+
+func TestOptionBlockParsesAccountIDs(t *testing.T) {
+	data := `
+- provider: aws
+  account_ids:
+    - "123456789012"
+    - "234567890123"
+`
+	var options Options
+	err := yaml.Unmarshal([]byte(data), &options)
+	require.NoError(t, err)
+	require.Len(t, options, 1)
+
+	value, ok := options[0].GetMetadata("account_ids")
+	require.True(t, ok)
+	require.Equal(t, "123456789012,234567890123", value)
+}
+
+func TestOptionBlockZeroPadsUnquotedAccountIDs(t *testing.T) {
+	data := `
+- provider: aws
+  account_ids:
+    - 012345678901
+    - 123456789012
+`
+	var options Options
+	err := yaml.Unmarshal([]byte(data), &options)
+	require.NoError(t, err)
+	require.Len(t, options, 1)
+
+	value, ok := options[0].GetMetadata("account_ids")
+	require.True(t, ok)
+	require.Equal(t, "012345678901,123456789012", value)
+}
+
+func TestOptionBlockZeroPadsExcludeAccountIDs(t *testing.T) {
+	data := `
+- provider: aws
+  exclude_account_ids:
+    - 012345678901
+`
+	var options Options
+	err := yaml.Unmarshal([]byte(data), &options)
+	require.NoError(t, err)
+	require.Len(t, options, 1)
+
+	value, ok := options[0].GetMetadata("exclude_account_ids")
+	require.True(t, ok)
+	require.Equal(t, "012345678901", value)
+}
+
+func TestOptionBlockScalarFallback(t *testing.T) {
+	data := `
+- provider: aws
+  assume_role_name: PDScannerRole
+`
+	var options Options
+	err := yaml.Unmarshal([]byte(data), &options)
+	require.NoError(t, err)
+	require.Len(t, options, 1)
+
+	value, ok := options[0].GetMetadata("assume_role_name")
+	require.True(t, ok)
+	require.Equal(t, "PDScannerRole", value)
+}


### PR DESCRIPTION
  - Add org_discovery_role_arn to auto-discover AWS accounts via organizations:ListAccounts
  - Add exclude_account_ids to skip specific accounts from scanning
  - Add validation to reject assume_role_arn combined with multi-account fields (assume_role_name, account_ids, org_discovery_role_arn) which would cause unintended role chaining
  - Fix exclude_account_ids YAML array parsing in schema
  - Fix hardcoded field name in schema error message

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * AWS Organizations account discovery via a configured discovery role
  * Account exclusion filtering that applies to both manual and discovered accounts
  * Discovery and exclusion performed during initialization with validation to prevent conflicting options and to verify discovery access

* **Bug Fixes**
  * Improved error reporting for invalid account configuration types
<!-- end of auto-generated comment: release notes by coderabbit.ai -->