### PR TITLE
fix(gcp): large org discovery failing silently due to rate limiting

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -147,7 +147,7 @@ require (
 	golang.org/x/text v0.32.0 // indirect
 	golang.org/x/time v0.12.0 // indirect
 	golang.org/x/tools v0.39.0 // indirect
-	google.golang.org/genproto/googleapis/rpc v0.0.0-20250603155806-513f23925822
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20250603155806-513f23925822 // indirect
 	google.golang.org/grpc v1.73.0
 	google.golang.org/protobuf v1.36.6
 	gopkg.in/inf.v0 v0.9.1 // indirect
@@ -182,7 +182,6 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/trafficmanager/armtrafficmanager v1.3.0
 	github.com/alitto/pond/v2 v2.3.2
 	github.com/dnsimple/dnsimple-go v1.7.0
-	github.com/golang-jwt/jwt/v5 v5.3.0
 	github.com/projectdiscovery/networkpolicy v0.1.34
 	github.com/projectdiscovery/retryablehttp-go v1.3.6
 )
@@ -215,6 +214,7 @@ require (
 	github.com/gaissmai/bart v0.26.0 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/gofrs/flock v0.8.1 // indirect
+	github.com/golang-jwt/jwt/v5 v5.3.0 // indirect
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
 	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -147,8 +147,8 @@ require (
 	golang.org/x/text v0.32.0 // indirect
 	golang.org/x/time v0.12.0 // indirect
 	golang.org/x/tools v0.39.0 // indirect
-	google.golang.org/genproto/googleapis/rpc v0.0.0-20250603155806-513f23925822 // indirect
-	google.golang.org/grpc v1.73.0 // indirect
+	google.golang.org/genproto/googleapis/rpc v0.0.0-20250603155806-513f23925822
+	google.golang.org/grpc v1.73.0
 	google.golang.org/protobuf v1.36.6
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/ini.v1 v1.66.6 // indirect
@@ -182,6 +182,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/trafficmanager/armtrafficmanager v1.3.0
 	github.com/alitto/pond/v2 v2.3.2
 	github.com/dnsimple/dnsimple-go v1.7.0
+	github.com/golang-jwt/jwt/v5 v5.3.0
 	github.com/projectdiscovery/networkpolicy v0.1.34
 	github.com/projectdiscovery/retryablehttp-go v1.3.6
 )
@@ -214,7 +215,6 @@ require (
 	github.com/gaissmai/bart v0.26.0 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/gofrs/flock v0.8.1 // indirect
-	github.com/golang-jwt/jwt/v5 v5.3.0 // indirect
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
 	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect

--- a/pkg/providers/gcp/gcp.go
+++ b/pkg/providers/gcp/gcp.go
@@ -531,6 +531,7 @@ pagination:
 				select {
 				case <-time.After(rateLimitWait):
 				case <-ctx.Done():
+					lastErr = ctx.Err()
 					break pagination
 				}
 

--- a/pkg/providers/gcp/gcp.go
+++ b/pkg/providers/gcp/gcp.go
@@ -512,6 +512,9 @@ pagination:
 				asset:    asset,
 				resource: resource,
 			})
+			if len(assetInfos)%5000 == 0 {
+				gologger.Info().Msgf("Progress: %d assets fetched so far", len(assetInfos))
+			}
 		}
 	}
 

--- a/pkg/providers/gcp/gcp.go
+++ b/pkg/providers/gcp/gcp.go
@@ -23,7 +23,6 @@ import (
 	"google.golang.org/api/option"
 	run "google.golang.org/api/run/v1"
 	"google.golang.org/api/storage/v1"
-	"google.golang.org/genproto/googleapis/rpc/errdetails"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/structpb"
@@ -383,7 +382,7 @@ func (p *OrganizationProvider) Resources(ctx context.Context) (*schema.Resources
 
 	// Use Cloud Asset Inventory API to get assets
 	if p.services.Has("all") {
-		gologger.Debug().Msgf("Found 'all' service, starting comprehensive asset discovery")
+		gologger.Info().Msgf("Found 'all' service, starting comprehensive asset discovery")
 		allAssets, err := p.getAllAssets(ctx, parent)
 		if err != nil {
 			gologger.Warning().Msgf("Could not get all assets: %s", err)
@@ -474,23 +473,19 @@ pagination:
 			}
 
 			// On rate limit, wait and resume from where we left off
-			if isRateLimit, retryDelay := rateLimitInfo(err); isRateLimit && rateLimitRetries < maxRateLimitRetries {
+			if rateLimitInfo(err) && rateLimitRetries < maxRateLimitRetries {
 				rateLimitRetries++
 				pageToken := it.PageInfo().Token
 
-				wait := rateLimitWait
-				if retryDelay > 0 {
-					wait = retryDelay
-				}
 				gologger.Debug().Msgf("Rate limit hit after %d assets, waiting %s before retry (%d/%d)",
-					len(assetInfos), wait, rateLimitRetries, maxRateLimitRetries)
+					len(assetInfos), rateLimitWait, rateLimitRetries, maxRateLimitRetries)
 
 				if pageToken == "" {
 					break
 				}
 
 				select {
-				case <-time.After(wait):
+				case <-time.After(rateLimitWait):
 				case <-ctx.Done():
 					break pagination
 				}
@@ -720,19 +715,12 @@ func newOrganizationProvider(options schema.OptionBlock, id, JSONData, organizat
 }
 
 // rateLimitInfo returns whether the error is a rate limit error and the suggested retry delay
-func rateLimitInfo(err error) (bool, time.Duration) {
+func rateLimitInfo(err error) bool {
 	s, ok := status.FromError(err)
 	if !ok || s.Code() != codes.ResourceExhausted {
-		return false, 0
+		return false
 	}
-	for _, detail := range s.Details() {
-		if retryInfo, ok := detail.(*errdetails.RetryInfo); ok {
-			if d := retryInfo.GetRetryDelay(); d != nil {
-				return true, d.AsDuration()
-			}
-		}
-	}
-	return true, 0
+	return true
 }
 
 // Helper functions to reduce nesting and improve readability

--- a/pkg/providers/gcp/gcp.go
+++ b/pkg/providers/gcp/gcp.go
@@ -462,6 +462,7 @@ func (p *OrganizationProvider) getAssetsForTypes(ctx context.Context, parent str
 	const maxRateLimitRetries = 10
 	const rateLimitWait = 90 * time.Second
 	var assetInfos []assetInfo
+	var lastErr error
 	rateLimitRetries := 0
 
 pagination:
@@ -473,16 +474,12 @@ pagination:
 			}
 
 			// On rate limit, wait and resume from where we left off
-			if rateLimitInfo(err) && rateLimitRetries < maxRateLimitRetries {
+			if isRateLimitError(err) && rateLimitRetries < maxRateLimitRetries {
 				rateLimitRetries++
 				pageToken := it.PageInfo().Token
 
 				gologger.Debug().Msgf("Rate limit hit after %d assets, waiting %s before retry (%d/%d)",
 					len(assetInfos), rateLimitWait, rateLimitRetries, maxRateLimitRetries)
-
-				if pageToken == "" {
-					break
-				}
 
 				select {
 				case <-time.After(rateLimitWait):
@@ -496,7 +493,8 @@ pagination:
 				continue
 			}
 
-			// Non-rate-limit error or max retries exceeded: return partial results
+			// Non-rate-limit error or max retries exceeded: save error and return partial results
+			lastErr = err
 			gologger.Debug().Msgf("ListAssets pagination stopped after %d assets: %s", len(assetInfos), err)
 			break
 		}
@@ -511,6 +509,11 @@ pagination:
 				gologger.Debug().Msgf("Progress: %d assets fetched so far", len(assetInfos))
 			}
 		}
+	}
+
+	// If we got 0 assets and had an error, return the error
+	if lastErr != nil && len(assetInfos) == 0 {
+		return nil, lastErr
 	}
 
 	// Bulk fetch extended metadata for all collected assets (if requested)
@@ -714,8 +717,8 @@ func newOrganizationProvider(options schema.OptionBlock, id, JSONData, organizat
 	return provider, nil
 }
 
-// rateLimitInfo returns whether the error is a rate limit error and the suggested retry delay
-func rateLimitInfo(err error) bool {
+// isRateLimitError returns whether the error is a rate limit error
+func isRateLimitError(err error) bool {
 	s, ok := status.FromError(err)
 	if !ok || s.Code() != codes.ResourceExhausted {
 		return false

--- a/pkg/providers/gcp/gcp.go
+++ b/pkg/providers/gcp/gcp.go
@@ -567,9 +567,14 @@ pagination:
 		}
 	}
 
-	// If we got 0 assets and had an error, return the error
-	if lastErr != nil && len(assetInfos) == 0 {
-		return nil, lastErr
+	// If we had an error, propagate cancellations immediately, otherwise return error only if empty.
+	if lastErr != nil {
+		if errors.Is(lastErr, context.Canceled) || errors.Is(lastErr, context.DeadlineExceeded) {
+			return nil, lastErr
+		}
+		if len(assetInfos) == 0 {
+			return nil, lastErr
+		}
 	}
 
 	// Bulk fetch extended metadata for all collected assets (if requested)

--- a/pkg/providers/gcp/gcp.go
+++ b/pkg/providers/gcp/gcp.go
@@ -482,7 +482,7 @@ pagination:
 				if retryDelay > 0 {
 					wait = retryDelay
 				}
-				gologger.Info().Msgf("Rate limit hit after %d assets, waiting %s before retry (%d/%d)",
+				gologger.Debug().Msgf("Rate limit hit after %d assets, waiting %s before retry (%d/%d)",
 					len(assetInfos), wait, rateLimitRetries, maxRateLimitRetries)
 
 				if pageToken == "" {
@@ -502,7 +502,7 @@ pagination:
 			}
 
 			// Non-rate-limit error or max retries exceeded: return partial results
-			gologger.Info().Msgf("ListAssets pagination stopped after %d assets: %s", len(assetInfos), err)
+			gologger.Debug().Msgf("ListAssets pagination stopped after %d assets: %s", len(assetInfos), err)
 			break
 		}
 
@@ -513,7 +513,7 @@ pagination:
 				resource: resource,
 			})
 			if len(assetInfos)%25000 == 0 {
-				gologger.Info().Msgf("Progress: %d assets fetched so far", len(assetInfos))
+				gologger.Debug().Msgf("Progress: %d assets fetched so far", len(assetInfos))
 			}
 		}
 	}

--- a/pkg/providers/gcp/gcp.go
+++ b/pkg/providers/gcp/gcp.go
@@ -383,10 +383,10 @@ func (p *OrganizationProvider) Resources(ctx context.Context) (*schema.Resources
 
 	// Use Cloud Asset Inventory API to get assets
 	if p.services.Has("all") {
-		gologger.Info().Msgf("Found 'all' service, starting comprehensive asset discovery")
+		gologger.Debug().Msgf("Found 'all' service, starting comprehensive asset discovery")
 		allAssets, err := p.getAllAssets(ctx, parent)
 		if err != nil {
-			gologger.Info().Msgf("Could not get all assets: %s", err)
+			gologger.Warning().Msgf("Could not get all assets: %s", err)
 		} else {
 			finalResources.Merge(allAssets)
 		}
@@ -395,7 +395,7 @@ func (p *OrganizationProvider) Resources(ctx context.Context) (*schema.Resources
 		for _, service := range p.services.Keys() {
 			assets, err := p.getAssetsForService(ctx, parent, service)
 			if err != nil {
-				gologger.Info().Msgf("Could not get assets for service %s: %s", service, err)
+				gologger.Warning().Msgf("Could not get assets for service %s: %s", service, err)
 			} else {
 				finalResources.Merge(assets)
 			}

--- a/pkg/providers/gcp/gcp.go
+++ b/pkg/providers/gcp/gcp.go
@@ -512,7 +512,7 @@ pagination:
 				asset:    asset,
 				resource: resource,
 			})
-			if len(assetInfos)%5000 == 0 {
+			if len(assetInfos)%25000 == 0 {
 				gologger.Info().Msgf("Progress: %d assets fetched so far", len(assetInfos))
 			}
 		}

--- a/pkg/providers/gcp/gcp.go
+++ b/pkg/providers/gcp/gcp.go
@@ -23,6 +23,9 @@ import (
 	"google.golang.org/api/option"
 	run "google.golang.org/api/run/v1"
 	"google.golang.org/api/storage/v1"
+	"google.golang.org/genproto/googleapis/rpc/errdetails"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/structpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
@@ -383,7 +386,7 @@ func (p *OrganizationProvider) Resources(ctx context.Context) (*schema.Resources
 		gologger.Info().Msgf("Found 'all' service, starting comprehensive asset discovery")
 		allAssets, err := p.getAllAssets(ctx, parent)
 		if err != nil {
-			gologger.Warning().Msgf("Could not get all assets: %s", err)
+			gologger.Info().Msgf("Could not get all assets: %s", err)
 		} else {
 			finalResources.Merge(allAssets)
 		}
@@ -392,7 +395,7 @@ func (p *OrganizationProvider) Resources(ctx context.Context) (*schema.Resources
 		for _, service := range p.services.Keys() {
 			assets, err := p.getAssetsForService(ctx, parent, service)
 			if err != nil {
-				gologger.Warning().Msgf("Could not get assets for service %s: %s", service, err)
+				gologger.Info().Msgf("Could not get assets for service %s: %s", service, err)
 			} else {
 				finalResources.Merge(assets)
 			}
@@ -456,16 +459,51 @@ func (p *OrganizationProvider) getAssetsForTypes(ctx context.Context, parent str
 	resources := schema.NewResources()
 	it := p.assetClient.ListAssets(ctx, req)
 
-	// Collect all assets first
+	// Collect all assets, with retry on rate limit errors and partial result preservation
+	const maxRateLimitRetries = 10
+	const rateLimitWait = 90 * time.Second
 	var assetInfos []assetInfo
+	rateLimitRetries := 0
 
+pagination:
 	for {
 		asset, err := it.Next()
 		if err != nil {
 			if errors.Is(err, iterator.Done) {
 				break
 			}
-			return nil, err
+
+			// On rate limit, wait and resume from where we left off
+			if isRateLimit, retryDelay := rateLimitInfo(err); isRateLimit && rateLimitRetries < maxRateLimitRetries {
+				rateLimitRetries++
+				pageToken := it.PageInfo().Token
+
+				wait := rateLimitWait
+				if retryDelay > 0 {
+					wait = retryDelay
+				}
+				gologger.Info().Msgf("Rate limit hit after %d assets, waiting %s before retry (%d/%d)",
+					len(assetInfos), wait, rateLimitRetries, maxRateLimitRetries)
+
+				if pageToken == "" {
+					break
+				}
+
+				select {
+				case <-time.After(wait):
+				case <-ctx.Done():
+					break pagination
+				}
+
+				// Resume with a new iterator using the page token
+				req.PageToken = pageToken
+				it = p.assetClient.ListAssets(ctx, req)
+				continue
+			}
+
+			// Non-rate-limit error or max retries exceeded: return partial results
+			gologger.Info().Msgf("ListAssets pagination stopped after %d assets: %s", len(assetInfos), err)
+			break
 		}
 
 		resource := p.parseAssetToResource(asset)
@@ -676,6 +714,22 @@ func newOrganizationProvider(options schema.OptionBlock, id, JSONData, organizat
 	provider.projects = projects
 
 	return provider, nil
+}
+
+// rateLimitInfo returns whether the error is a rate limit error and the suggested retry delay
+func rateLimitInfo(err error) (bool, time.Duration) {
+	s, ok := status.FromError(err)
+	if !ok || s.Code() != codes.ResourceExhausted {
+		return false, 0
+	}
+	for _, detail := range s.Details() {
+		if retryInfo, ok := detail.(*errdetails.RetryInfo); ok {
+			if d := retryInfo.GetRetryDelay(); d != nil {
+				return true, d.AsDuration()
+			}
+		}
+	}
+	return true, 0
 }
 
 // Helper functions to reduce nesting and improve readability


### PR DESCRIPTION
  ## Summary
  - Fix Cloud Asset API `ListAssets` pagination silently discarding all collected assets when hitting rate limits mid-stream (100 req/min per project quota)
  - Add retry with backoff (10 retries, 90s wait) using page token resumption to progressively collect assets across rate limit windows
  - Return partial results instead of nil when pagination errors occur, preventing total data loss

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GCP asset listing to handle rate-limit errors with automatic retries and waits while preserving partial results.
  * Respects cancellation, resumes from the last collected position after retry, and returns an error only if no assets were collected.
  * Adds periodic progress logging during large collections for better visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->