### PR TITLE
fix(aws): improve verify  - check all accounts and improve role assumption reliability

### DIFF
--- a/pkg/providers/aws/aws.go
+++ b/pkg/providers/aws/aws.go
@@ -249,16 +249,21 @@ func New(block schema.OptionBlock) (*Provider, error) {
 
 	if err != nil && options.AssumeRoleName != "" && len(options.AccountIds) > 0 {
 		// Base user doesn't have DescribeRegions permission, try with assumed role
-		tempSession, err := createAssumedRoleSession(options, sess, config, options.AccountIds[0])
-		if err != nil {
-			return nil, errors.Wrap(err, "could not create assumed role session")
+		var regionErr error
+		for _, accountId := range options.AccountIds {
+			tempSession, err := createAssumedRoleSession(options, sess, config, accountId)
+			if err != nil {
+				regionErr = err
+				continue
+			}
+			tempRC := ec2.New(tempSession)
+			regions, regionErr = tempRC.DescribeRegions(&ec2.DescribeRegionsInput{})
+			if regionErr == nil {
+				break
+			}
 		}
-
-		// Use assumed role session for DescribeRegions
-		tempRC := ec2.New(tempSession)
-		regions, err = tempRC.DescribeRegions(&ec2.DescribeRegionsInput{})
-		if err != nil {
-			return nil, errors.Wrap(err, "could not get list of regions even with assumed role")
+		if regionErr != nil {
+			return nil, errors.Wrap(regionErr, "could not get list of regions with any account")
 		}
 	} else if err != nil {
 		return nil, errors.Wrap(err, "could not get list of regions")

--- a/pkg/providers/aws/aws.go
+++ b/pkg/providers/aws/aws.go
@@ -521,21 +521,40 @@ func (p *Provider) Verify(ctx context.Context) error {
 	}
 
 	if p.options.AssumeRoleName != "" && len(p.options.AccountIds) > 0 {
-		var lastErr error
+		var mu sync.Mutex
+		var failedAccounts []string
+		var wg sync.WaitGroup
+
 		for _, accountId := range p.options.AccountIds {
-			tempSession, err := createAssumedRoleSession(p.options, p.session, p.session.Config, accountId)
-			if err != nil {
-				lastErr = err
-				continue
-			}
-			p.initServices(tempSession)
-			if err := p.verify(); err != nil {
-				lastErr = err
-				continue
-			}
-			return nil
+			wg.Add(1)
+			go func(id string) {
+				defer wg.Done()
+				tempSession, err := createAssumedRoleSession(p.options, p.session, p.session.Config, id)
+				if err != nil {
+					mu.Lock()
+					failedAccounts = append(failedAccounts, id)
+					mu.Unlock()
+					return
+				}
+				tempProvider := &Provider{options: p.options, session: tempSession}
+				tempProvider.initServices(tempSession)
+				if err := tempProvider.verify(); err != nil {
+					mu.Lock()
+					failedAccounts = append(failedAccounts, id)
+					mu.Unlock()
+				}
+			}(accountId)
 		}
-		return errors.Wrap(lastErr, "failed to verify credentials across all accounts")
+		wg.Wait()
+
+		if len(failedAccounts) > 0 {
+			msg := fmt.Sprintf("failed to assume role %s in accounts: %s", p.options.AssumeRoleName, strings.Join(failedAccounts, ", "))
+			if p.options.OrgDiscoveryRoleArn != "" {
+				msg += ". Add these to exclude_account_ids if they should not be part of discovery"
+			}
+			return errors.New(msg)
+		}
+		return nil
 	}
 	return err
 }

--- a/pkg/providers/aws/aws.go
+++ b/pkg/providers/aws/aws.go
@@ -529,11 +529,14 @@ func (p *Provider) Verify(ctx context.Context) error {
 		var mu sync.Mutex
 		var failedAccounts []string
 		var wg sync.WaitGroup
+		sem := make(chan struct{}, 200)
 
 		for _, accountId := range p.options.AccountIds {
 			wg.Add(1)
+			sem <- struct{}{}
 			go func(id string) {
 				defer wg.Done()
+				defer func() { <-sem }()
 				tempSession, err := createAssumedRoleSession(p.options, p.session, p.session.Config, id)
 				if err != nil {
 					mu.Lock()

--- a/pkg/providers/aws/aws.go
+++ b/pkg/providers/aws/aws.go
@@ -249,7 +249,7 @@ func New(block schema.OptionBlock) (*Provider, error) {
 
 	if err != nil && options.AssumeRoleName != "" && len(options.AccountIds) > 0 {
 		// Base user doesn't have DescribeRegions permission, try with assumed role
-		tempSession, err := createAssumedRoleSession(options, sess, config)
+		tempSession, err := createAssumedRoleSession(options, sess, config, options.AccountIds[0])
 		if err != nil {
 			return nil, errors.Wrap(err, "could not create assumed role session")
 		}
@@ -270,12 +270,9 @@ func New(block schema.OptionBlock) (*Provider, error) {
 	return provider, nil
 }
 
-func createAssumedRoleSession(options *ProviderOptions, sess *session.Session, config *aws.Config) (*session.Session, error) {
-	if len(options.AccountIds) == 0 {
-		return nil, errors.New("no account IDs provided for assume role")
-	}
+func createAssumedRoleSession(options *ProviderOptions, sess *session.Session, config *aws.Config, accountId string) (*session.Session, error) {
 	stsClient := sts.New(sess)
-	roleArn := fmt.Sprintf("arn:aws:iam::%s:role/%s", options.AccountIds[0], options.AssumeRoleName)
+	roleArn := fmt.Sprintf("arn:aws:iam::%s:role/%s", accountId, options.AssumeRoleName)
 
 	roleInput := &sts.AssumeRoleInput{
 		RoleArn: aws.String(roleArn),
@@ -524,16 +521,21 @@ func (p *Provider) Verify(ctx context.Context) error {
 	}
 
 	if p.options.AssumeRoleName != "" && len(p.options.AccountIds) > 0 {
-		tempSession, err := createAssumedRoleSession(p.options, p.session, p.session.Config)
-		if err != nil {
-			return err
+		var lastErr error
+		for _, accountId := range p.options.AccountIds {
+			tempSession, err := createAssumedRoleSession(p.options, p.session, p.session.Config, accountId)
+			if err != nil {
+				lastErr = err
+				continue
+			}
+			p.initServices(tempSession)
+			if err := p.verify(); err != nil {
+				lastErr = err
+				continue
+			}
+			return nil
 		}
-		p.initServices(tempSession)
-		err = p.verify()
-		if err != nil {
-			return err
-		}
-		return nil
+		return errors.Wrap(lastErr, "failed to verify credentials across all accounts")
 	}
 	return err
 }


### PR DESCRIPTION

  Summary
  - Parallel account verification: Verify() now checks role assumption against all account IDs concurrently instead of only the first one.
  Reports all failed account IDs in a single actionable error message.
  - Resilient region discovery: New() now iterates through account IDs when the base session lacks DescribeRegions permission, instead of failing
   on the first account.
  - Explicit account ID in role assumption: createAssumedRoleSession now takes an explicit accountId parameter instead of hardcoding
  AccountIds[0].
  
  Context

  With org discovery, account ordering is arbitrary — the first account may not have the scanner role configured. Previously, verification only checked the first account in the list — if it passed, the entire verification was considered successful, even if other accounts lacked the scanner role. This meant broken accounts were silently skipped during enumeration. Now all accounts are verified in parallel, and the error message lists exactly which accounts failed, with guidance to add them to exclude_account_ids when using org discovery.
  
  Changes
  - createAssumedRoleSession — accepts accountId param instead of using AccountIds[0]
  - New() — loops through accounts for DescribeRegions fallback until one succeeds
  - Verify() — checks all accounts in parallel using goroutines, collects and reports failures
    - Org discovery: suggests adding failed accounts to exclude_account_ids
    - Manual account_ids: reports failure without the suggestion

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Multi-account region discovery now tries each configured account when the base user lacks region permissions, improving success rates.
  * Role verification runs in parallel across accounts for faster validation.
  * Error messages and reporting for multi-account failures have been clarified and consolidated, including guidance when organization-level discovery is configured.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->