### PR TITLE
fix: handle nil AWS ALB entries

### DIFF
--- a/pkg/providers/aws/alb.go
+++ b/pkg/providers/aws/alb.go
@@ -74,7 +74,7 @@ func (ep *elbV2Provider) listELBV2Resources(albClient *elbv2.ELBV2, ec2Client *e
 	}
 
 	for _, lb := range loadBalancers {
-		if lb.DNSName == nil || lb.LoadBalancerName == nil {
+		if lb == nil || lb.DNSName == nil || lb.LoadBalancerName == nil {
 			continue
 		}
 		albDNS := *lb.DNSName

--- a/pkg/providers/aws/alb_test.go
+++ b/pkg/providers/aws/alb_test.go
@@ -15,7 +15,7 @@ import (
 func processLoadBalancersForTest(lbs []*elbv2.LoadBalancer) *schema.Resources {
 	list := schema.NewResources()
 	for _, lb := range lbs {
-		if lb.DNSName == nil || lb.LoadBalancerName == nil {
+		if lb == nil || lb.DNSName == nil || lb.LoadBalancerName == nil {
 			continue
 		}
 		list.Append(&schema.Resource{
@@ -41,10 +41,11 @@ func processTargetsForTest(targets []*elbv2.TargetHealthDescription) []string {
 	return ids
 }
 
-func TestListELBV2Resources_NilDNSName(t *testing.T) {
+func TestListELBV2Resources_NilLoadBalancer(t *testing.T) {
 	t.Parallel()
 
 	lbs := []*elbv2.LoadBalancer{
+		nil,
 		{
 			DNSName:         nil,
 			LoadBalancerName: aws.String("internal-lb"),
@@ -58,7 +59,7 @@ func TestListELBV2Resources_NilDNSName(t *testing.T) {
 
 	require.NotPanics(t, func() {
 		resources := processLoadBalancersForTest(lbs)
-		assert.Equal(t, 0, len(resources.Items), "nil DNSName or LoadBalancerName LBs must be skipped")
+		assert.Equal(t, 0, len(resources.Items), "nil or incomplete load balancers must be skipped")
 	})
 }
 


### PR DESCRIPTION
## Summary
- Defensively skip nil load balancer entries returned by ELBv2.
- Extend the existing ALB nil-safety test to cover nil entries.

Follow-up to #743, which guards nil ALB fields but still dereferences the load-balancer pointer before checking it.

## Test
- `go test ./pkg/providers/aws`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved load balancer resource listing to safely ignore empty or incomplete load balancer entries.
  * Prevented potential errors when load balancer data is missing entirely.

* **Tests**
  * Added coverage for load balancer entries that are unexpectedly empty.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->